### PR TITLE
collect-logs improvements

### DIFF
--- a/v2/terraform_flannel.py
+++ b/v2/terraform_flannel.py
@@ -483,8 +483,8 @@ class Terraform_Flannel(ci.CI):
         log_pods = out.splitlines()
         for pod in log_pods:
             if not utils.wait_for_ready_pod(pod):
-                self.logging.error("Timed out waiting for pod to be ready: %s", pod)
-                raise Exception("Timed out waiting for pod to be ready: %s", pod)
+                self.logging.warning("Timed out waiting for pod to be ready: %s", pod)
+                continue
 
             cmd = [kubectl, "get", "pod", pod, "--output=custom-columns=NODE:.spec.nodeName", "--no-headers"]
             vm_name, err, ret = utils.run_cmd(cmd, stdout=True, stderr=True, shell=True)

--- a/v2/utils.py
+++ b/v2/utils.py
@@ -307,7 +307,7 @@ def wait_for_ready_pod(pod_name, timeout=300):
         time.sleep(5)
 
 
-def daemonset_cleanup(daemonset_yaml, daemonset_name, timeout=300):
+def daemonset_cleanup(daemonset_yaml, daemonset_name, timeout=600):
     logging.info("Cleaning up daemonset: %s", daemonset_name)
 
     kubectl = get_kubectl_bin()


### PR DESCRIPTION
Make collect-log pod timeout non-fatal
Increase default pod wait time to 600s