### PR TITLE
Capz Flannel CI Updates

### DIFF
--- a/e2e-runner/cluster-api/flannel/kube-flannel-windows.Dockerfile
+++ b/e2e-runner/cluster-api/flannel/kube-flannel-windows.Dockerfile
@@ -5,7 +5,7 @@ SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $P
 
 RUN mkdir -force C:\k\flannel; \
     pushd C:\k\flannel; \
-    curl.exe -LO https://github.com/coreos/flannel/releases/download/v0.12.0/flanneld.exe
+    curl.exe -LO https://github.com/coreos/flannel/releases/download/v0.13.0-rc1/flanneld.exe
 
 RUN mkdir C:\utils; \
     curl.exe -Lo C:\utils\wins.exe https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe; \

--- a/e2e-runner/cluster-api/flannel/kube-flannel-windows.yaml.j2
+++ b/e2e-runner/cluster-api/flannel/kube-flannel-windows.yaml.j2
@@ -94,7 +94,7 @@ spec:
         effect: NoSchedule
       initContainers:
       - name: install-cni
-        image: e2eteam/flannel-windows:v0.12.0-{{ server_core_tag }}
+        image: e2eteam/flannel-windows:v0.13.0-rc1-{{ server_core_tag }}
         imagePullPolicy: Always
         command:
         - powershell
@@ -118,7 +118,7 @@ spec:
           mountPath: /etc/kubeadm-config/
       containers:
       - name: kube-flannel
-        image: e2eteam/flannel-windows:v0.12.0-{{ server_core_tag }}
+        image: e2eteam/flannel-windows:v0.13.0-rc1-{{ server_core_tag }}
         imagePullPolicy: Always
         command:
         - powershell

--- a/e2e-runner/installPatches.ps1
+++ b/e2e-runner/installPatches.ps1
@@ -5,80 +5,115 @@
 #  2 - download failure
 #  3 - unrecognized patch extension
 
-param(
-    [string[]] $URIs
+Param(
+    [string[]]$URIs
 )
 
-function DownloadFile([string] $URI, [string] $fullName)
-{
-    try {
-        Write-Host "Downloading $URI"
-        $ProgressPreference = 'SilentlyContinue'
-        Invoke-WebRequest -UseBasicParsing $URI -OutFile $fullName
-    } catch {
-        Write-Error $_
-        exit 2
+$ErrorActionPreference = "Stop"
+
+
+function Start-ExecuteWithRetry {
+    Param(
+        [Parameter(Mandatory=$true)]
+        [ScriptBlock]$ScriptBlock,
+        [int]$MaxRetryCount=10,
+        [int]$RetryInterval=3,
+        [string]$RetryMessage,
+        [array]$ArgumentList=@()
+    )
+    $currentErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    $retryCount = 0
+    while ($true) {
+        Write-Output "Start-ExecuteWithRetry attempt $retryCount"
+        try {
+            $res = Invoke-Command -ScriptBlock $ScriptBlock `
+                                  -ArgumentList $ArgumentList
+            $ErrorActionPreference = $currentErrorActionPreference
+            Write-Output "Start-ExecuteWithRetry terminated"
+            return $res
+        } catch [System.Exception] {
+            $retryCount++
+            if ($retryCount -gt $MaxRetryCount) {
+                $ErrorActionPreference = $currentErrorActionPreference
+                Write-Output "Start-ExecuteWithRetry exception thrown"
+                throw
+            } else {
+                if($RetryMessage) {
+                    Write-Output "Start-ExecuteWithRetry RetryMessage: $RetryMessage"
+                } elseif($_) {
+                    Write-Output "Start-ExecuteWithRetry Retry: $_.ToString()"
+                }
+                Start-Sleep $RetryInterval
+            }
+        }
     }
 }
 
+function Start-FileDownload {
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string]$URL,
+        [Parameter(Mandatory=$true)]
+        [string]$Destination,
+        [Parameter(Mandatory=$false)]
+        [int]$RetryCount=10
+    )
+    if(Test-Path $Destination) {
+        Remove-Item -Force $Destination
+    }
+    Start-ExecuteWithRetry -ScriptBlock {
+        curl.exe -C - -L -s -o $Destination $URL
+        if($LASTEXITCODE) {
+            Throw "Failed to download $URL"
+        }
+    } -MaxRetryCount $RetryCount -RetryInterval 3 -RetryMessage "Failed to download $URL. Retrying"
+}
 
-$URIs | ForEach-Object {
-    Write-Host "Processing $_"
-    $uri = $_
+
+foreach($uri in $URIs) {
+    Write-Host "Processing $uri"
     $pathOnly = $uri
-    if ($pathOnly.Contains("?"))
-    {
+    if ($pathOnly.Contains("?")) {
         $pathOnly = $pathOnly.Split("?")[0]
     }
     $fileName = Split-Path $pathOnly -Leaf
     $ext = [io.path]::GetExtension($fileName)
     $fullName = [io.path]::Combine($env:TEMP, $fileName)
+    Start-FileDownload -URL $uri -Destination $fullName
     switch ($ext) {
         ".exe" {
             Start-Process -FilePath bcdedit.exe -ArgumentList "/set {current} testsigning on" -Wait
-            DownloadFile -URI $uri -fullName $fullName
             Write-Host "Starting $fullName"
-            $proc = Start-Process -Passthru -FilePath "$fullName" -ArgumentList "/q /norestart"
-            Wait-Process -InputObject $proc
-            switch ($proc.ExitCode)
-            {
-                0 {
-                    Write-Host "Finished running $fullName"
-                }
-                3010 {
-                    Write-Host "Finished running $fullName. Reboot required to finish patching."
-                }
-                Default {
-                    Write-Error "Error running $fullName, exitcode $($proc.ExitCode)"
-                    exit 1
-                }
-            }
+            $proc = Start-Process -Passthru -Wait -FilePath "$fullName" -ArgumentList "/q /norestart"
         }
         ".msu" {
-            DownloadFile -URI $uri -fullName $fullName
             Write-Host "Installing $fullName"
-            $proc = Start-Process -Passthru -FilePath wusa.exe -ArgumentList "$fullName /quiet /norestart"
-            Wait-Process -InputObject $proc
-            switch ($proc.ExitCode)
-            {
-                0 {
-                    Write-Host "Finished running $fullName"
-                }
-                3010 {
-                    Write-Host "Finished running $fullName. Reboot required to finish patching."
-                }
-                Default {
-                    Write-Error "Error running $fullName, exitcode $($proc.ExitCode)"
-                    exit 1
-                }
-            }
+            $proc = Start-Process -Passthru -Wait -FilePath wusa.exe -ArgumentList "$fullName /quiet /norestart"
+        }
+        ".cab" {
+            Write-Host "Installing $fullName"
+            $proc = Start-Process -Passthru -Wait -FilePath DISM.exe -ArgumentList "/Online /Add-Package /PackagePath:$fullName /Quiet /NoRestart"
         }
         Default {
             Write-Error "This script extension doesn't know how to install $ext files"
             exit 3
         }
     }
+
+    switch ($proc.ExitCode) {
+        0 {
+            Write-Host "Finished running $fullName"
+        }
+        3010 {
+            Write-Host "Finished running $fullName. Reboot required to finish patching."
+        }
+        Default {
+            Write-Error "Error running $fullName, exitcode $($proc.ExitCode)"
+            exit 1
+        }
+    }
 }
 
 # No failures, reboot now
-Restart-Computer
+Restart-Computer -Force

--- a/e2e-runner/utils.py
+++ b/e2e-runner/utils.py
@@ -512,12 +512,12 @@ def run_shell_cmd(cmd, cwd=None, env=None, sensitive=False):
     return (out, err)
 
 
-def run_async_shell_cmd(cmd, args):
+def run_async_shell_cmd(cmd, args, log_prefix=""):
     def process_stdout(line):
-        logging.info(line.strip())
+        logging.info(log_prefix + line.strip())
 
     def process_stderr(line):
-        logging.warning(line.strip())
+        logging.warning(log_prefix + line.strip())
 
     proc = cmd(args, _out=process_stdout, _err=process_stderr, _bg=True)
     return proc

--- a/image-builder/azure-cbsl-init/CustomResources/containerd/PrepareNode.ps1
+++ b/image-builder/azure-cbsl-init/CustomResources/containerd/PrepareNode.ps1
@@ -74,7 +74,7 @@ function Start-ContainerImagesPull {
         (Get-KubernetesPauseImage),
         (Get-NanoServerImage),
         "mcr.microsoft.com/windows/servercore:${windowsRelease}",
-        "docker.io/e2eteam/flannel-windows:v0.12.0-windowsservercore-${windowsRelease}",
+        "docker.io/e2eteam/flannel-windows:v0.13.0-rc1-windowsservercore-${windowsRelease}",
         "docker.io/e2eteam/kube-proxy-windows:${KubernetesVersion}-windowsservercore-${windowsRelease}"
     )
     foreach($img in $images) {

--- a/image-builder/azure-cbsl-init/CustomResources/docker/PrepareNode.ps1
+++ b/image-builder/azure-cbsl-init/CustomResources/docker/PrepareNode.ps1
@@ -42,7 +42,7 @@ function Start-ContainerImagesPull {
         (Get-KubernetesPauseImage),
         (Get-NanoServerImage),
         "mcr.microsoft.com/windows/servercore:${windowsRelease}",
-        "e2eteam/flannel-windows:v0.12.0-windowsservercore-${windowsRelease}",
+        "e2eteam/flannel-windows:v0.13.0-rc1-windowsservercore-${windowsRelease}",
         "e2eteam/kube-proxy-windows:${KubernetesVersion}-windowsservercore-${windowsRelease}",
         "e2eteam/busybox:1.29",
         "e2eteam/curl:1803",


### PR DESCRIPTION
* Bump Flannel version to `v0.13.0-rc1`. Since commit f964a9a got merged, there is a bug with overlay networks, and pods do not have connectivity. This issue is solved with Flannel `v0.13.0-rc1`.

* Improve installPatches.ps1 script Adds support for installing `cab` packages.

* Use async cmds to install patches on all workers at once