### PR TITLE
Image builder updates

### DIFF
--- a/image-builder/packer/azure-cbsl-init/k8s-node-setup/common.ps1
+++ b/image-builder/packer/azure-cbsl-init/k8s-node-setup/common.ps1
@@ -5,6 +5,9 @@ $ETC_DIR = Join-Path $env:SystemDrive "etc"
 $NSSM_DIR = Join-Path $env:ProgramFiles "nssm"
 $OPT_DIR = Join-Path $env:SystemDrive "opt"
 
+$CNI_PLUGINS_VERSION = "0.9.1"
+$WINDOWS_CNI_PLUGINS_VERSION = "0.2.0"
+
 
 function Start-ExecuteWithRetry {
     Param(
@@ -184,8 +187,7 @@ function Install-Kubelet {
 function Install-CNI {
     mkdir -force "$OPT_DIR\cni\bin"
 
-    $cniVersion = "v0.8.7"
-    Start-FileDownload "https://github.com/containernetworking/plugins/releases/download/${cniVersion}/cni-plugins-windows-amd64-${cniVersion}.tgz" `
+    Start-FileDownload "https://github.com/containernetworking/plugins/releases/download/v${CNI_PLUGINS_VERSION}/cni-plugins-windows-amd64-v${CNI_PLUGINS_VERSION}.tgz" `
                        "$env:TEMP\cni-plugins.tgz"
     tar -xf $env:TEMP\cni-plugins.tgz -C "$OPT_DIR\cni\bin"
     if($LASTEXITCODE) {
@@ -193,8 +195,7 @@ function Install-CNI {
     }
     Remove-Item -Force $env:TEMP\cni-plugins.tgz
 
-    $cniVersion = "v0.2.0"
-    Start-FileDownload "https://github.com/microsoft/windows-container-networking/releases/download/${cniVersion}/windows-container-networking-cni-amd64-${cniVersion}.zip" `
+    Start-FileDownload "https://github.com/microsoft/windows-container-networking/releases/download/v${WINDOWS_CNI_PLUGINS_VERSION}/windows-container-networking-cni-amd64-v${WINDOWS_CNI_PLUGINS_VERSION}.zip" `
                        "$env:TEMP\windows-container-networking-cni.zip"
     tar -xf $env:TEMP\windows-container-networking-cni.zip -C $OPT_DIR\cni\bin
     if($LASTEXITCODE) {

--- a/image-builder/packer/azure-cbsl-init/k8s-node-setup/containerd/PrepareNode.ps1
+++ b/image-builder/packer/azure-cbsl-init/k8s-node-setup/containerd/PrepareNode.ps1
@@ -4,6 +4,9 @@ $ErrorActionPreference = "Stop"
 
 $CONTAINERD_DIR = Join-Path $env:SystemDrive "containerd"
 
+$CRI_CONTAINERD_VERSION = "1.4.3"
+$CRICTL_VERSION = "1.20.0"
+
 
 function Install-Containerd {
     mkdir -force $CONTAINERD_DIR
@@ -11,8 +14,7 @@ function Install-Containerd {
     mkdir -force $VAR_LOG_DIR
     mkdir -force "$ETC_DIR\cni\net.d"
 
-    $criContainerdVersion = "1.4.3"
-    Start-FileDownload "https://github.com/containerd/containerd/releases/download/v${criContainerdVersion}/cri-containerd-cni-${criContainerdVersion}-windows-amd64.tar.gz" "$env:TEMP\cri-containerd-windows-amd64.tar.gz"
+    Start-FileDownload "https://github.com/containerd/containerd/releases/download/v${CRI_CONTAINERD_VERSION}/cri-containerd-cni-${CRI_CONTAINERD_VERSION}-windows-amd64.tar.gz" "$env:TEMP\cri-containerd-windows-amd64.tar.gz"
     tar xzf $env:TEMP\cri-containerd-windows-amd64.tar.gz -C $CONTAINERD_DIR
     if($LASTEXITCODE) {
         Throw "Failed to unzip containerd.zip"
@@ -20,8 +22,7 @@ function Install-Containerd {
     Add-ToSystemPath $CONTAINERD_DIR
     Remove-Item -Force "$env:TEMP\cri-containerd-windows-amd64.tar.gz"
 
-    $crictlVersion = "1.20.0"
-    Start-FileDownload "https://github.com/kubernetes-sigs/cri-tools/releases/download/v${crictlVersion}/crictl-v${crictlVersion}-windows-amd64.tar.gz" "$env:TEMP\crictl-windows-amd64.tar.gz"
+    Start-FileDownload "https://github.com/kubernetes-sigs/cri-tools/releases/download/v${CRICTL_VERSION}/crictl-v${CRICTL_VERSION}-windows-amd64.tar.gz" "$env:TEMP\crictl-windows-amd64.tar.gz"
     tar xzf $env:TEMP\crictl-windows-amd64.tar.gz -C $KUBERNETES_DIR
     if($LASTEXITCODE) {
         Throw "Failed to unzip crictl.zip"

--- a/image-builder/packer/azure-cbsl-init/windows-ltsc2019-containerd-variables.json
+++ b/image-builder/packer/azure-cbsl-init/windows-ltsc2019-containerd-variables.json
@@ -10,6 +10,6 @@
 
   "sig_name": "capz_gallery",
   "sig_image_name": "ws-ltsc2019-containerd-cbsl-init",
-  "sig_image_version": "1.20.2",
+  "sig_image_version": "2021.02.10",
   "sig_image_replication_regions": "westeurope,eastus2,westus2,southcentralus"
 }

--- a/image-builder/packer/azure-cbsl-init/windows-ltsc2019-docker-variables.json
+++ b/image-builder/packer/azure-cbsl-init/windows-ltsc2019-docker-variables.json
@@ -10,6 +10,6 @@
 
   "sig_name": "capz_gallery",
   "sig_image_name": "ws-ltsc2019-docker-cbsl-init",
-  "sig_image_version": "1.20.2",
+  "sig_image_version": "2021.02.10",
   "sig_image_replication_regions": "westeurope,eastus2,westus2,southcentralus"
 }

--- a/image-builder/packer/azure-cbsl-init/windows-sac1909-containerd-variables.json
+++ b/image-builder/packer/azure-cbsl-init/windows-sac1909-containerd-variables.json
@@ -10,6 +10,6 @@
 
   "sig_name": "capz_gallery",
   "sig_image_name": "ws-1909-containerd-cbsl-init",
-  "sig_image_version": "1.20.2",
+  "sig_image_version": "2021.02.10",
   "sig_image_replication_regions": "westeurope,eastus2,westus2,southcentralus"
 }

--- a/image-builder/packer/azure-cbsl-init/windows-sac2004-containerd-variables.json
+++ b/image-builder/packer/azure-cbsl-init/windows-sac2004-containerd-variables.json
@@ -10,6 +10,6 @@
 
   "sig_name": "capz_gallery",
   "sig_image_name": "ws-2004-containerd-cbsl-init",
-  "sig_image_version": "1.20.2",
+  "sig_image_version": "2021.02.10",
   "sig_image_replication_regions": "westeurope,eastus2,westus2,southcentralus"
 }

--- a/prow-config.yaml
+++ b/prow-config.yaml
@@ -171,7 +171,7 @@ data:
             - "--win-minion-count=2"
             - "--enable-win-dsr=True"
             - "--container-runtime=docker"
-            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:1.20.2"
+            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.02.10"
             - "--cluster-name=capzflannel-l2br-$(BUILD_ID)"
 
     - cron: "0 3/12 * * *"
@@ -207,7 +207,7 @@ data:
             - "--win-minion-count=2"
             - "--enable-win-dsr=True"
             - "--container-runtime=docker"
-            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:1.20.2"
+            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.02.10"
             - "--cluster-name=capzflannel-ovrl-$(BUILD_ID)"
 
     - cron: "0 6/12 * * *"
@@ -245,7 +245,7 @@ data:
             - "--win-minion-count=2"
             - "--enable-win-dsr=True"
             - "--container-runtime=containerd"
-            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:1.20.2"
+            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.02.10"
             - "--cluster-name=capzctrd-$(BUILD_ID)"
 
     - cron: "0 9/12 * * *"
@@ -283,7 +283,7 @@ data:
             - "--win-minion-count=2"
             - "--enable-win-dsr=True"
             - "--container-runtime=containerd"
-            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:1.20.2"
+            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.02.10"
             - "--cluster-name=capzctrd-$(BUILD_ID)"
 
     - cron: "0 2 * * *"
@@ -321,7 +321,7 @@ data:
             - "--enable-win-dsr=True"
             - "--container-runtime=containerd"
             - "--base-container-image-tag=1909"
-            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-1909-containerd-cbsl-init:1.20.2"
+            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-1909-containerd-cbsl-init:2021.02.10"
             - "--cluster-name=capzctrd1909-$(BUILD_ID)"
 
     - cron: "0 8 * * *"
@@ -359,7 +359,7 @@ data:
             - "--enable-win-dsr=True"
             - "--container-runtime=containerd"
             - "--base-container-image-tag=1909"
-            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-1909-containerd-cbsl-init:1.20.2"
+            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-1909-containerd-cbsl-init:2021.02.10"
             - "--cluster-name=capzctrd1909-$(BUILD_ID)"
 
     - cron: "0 14 * * *"
@@ -398,7 +398,7 @@ data:
             - "--enable-win-dsr=True"
             - "--container-runtime=containerd"
             - "--base-container-image-tag=2004"
-            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:1.20.2"
+            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.02.10"
             - "--cluster-name=capzctrd2004-$(BUILD_ID)"
 
     - cron: "0 20 * * *"
@@ -437,5 +437,5 @@ data:
             - "--enable-win-dsr=True"
             - "--container-runtime=containerd"
             - "--base-container-image-tag=2004"
-            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:1.20.2"
+            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.02.10"
             - "--cluster-name=capzctrd2004-$(BUILD_ID)"


### PR DESCRIPTION
* Bump CNI plugins version.
  * Use global variables for the dependencies versions.
* Bump Azure Packer images to `2021-02-10` version.