### PR TITLE
Disable IPv6 feature gate

### DIFF
--- a/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/kube-proxy-windows.yaml.j2
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/kube-proxy-windows.yaml.j2
@@ -27,6 +27,7 @@ data:
     yq w -i /host/var/lib/kube-proxy/config.conf winkernel.enableDSR {{ enable_win_dsr }}
     yq w -i /host/var/lib/kube-proxy/config.conf featureGates.WinDSR {{ enable_win_dsr }}
 {%- endif %}
+    yq w -i /host/var/lib/kube-proxy/config.conf featureGates.IPv6DualStack false
     yq w -i /host/var/lib/kube-proxy/config.conf mode "kernelspace"
 
   run.ps1: |


### PR DESCRIPTION
The IPv6DualStack feature was recently enabled by default on Windows.

It currently crashes the `kube-proxy` on start with:
```
F0222 server.go:490] unable to create proxier: unable to create ipv4 proxier:
Could not find host mac address for 0.0.0.0, hostname: ibflannel-m4n87, clusterCIDR : 10.244.0.0/16, nodeIP:0.0.0.0
```