### PR TITLE
CI Fixes

### DIFF
--- a/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/kube-proxy-windows.yaml.j2
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/kube-proxy-windows.yaml.j2
@@ -27,6 +27,7 @@ data:
     yq w -i /host/var/lib/kube-proxy/config.conf winkernel.enableDSR {{ enable_win_dsr }}
     yq w -i /host/var/lib/kube-proxy/config.conf featureGates.WinDSR {{ enable_win_dsr }}
 {%- endif %}
+    yq w -i /host/var/lib/kube-proxy/config.conf featureGates.IPv6DualStack false
     yq w -i /host/var/lib/kube-proxy/config.conf mode "kernelspace"
 
   run.ps1: |

--- a/e2e-runner/e2e_runner/cli/run_ci.py
+++ b/e2e-runner/e2e_runner/cli/run_ci.py
@@ -130,6 +130,15 @@ class RunCI(Command):
                        help="Number of Windows minions for the deployment.")
         p.add_argument("--win-minion-size", default="Standard_D2s_v3",
                        help="Size of Windows minions.")
+        p.add_argument("--win-minion-image-type", type=str,
+                       default=constants.SHARED_IMAGE_GALLERY_TYPE,
+                       choices=[constants.SHARED_IMAGE_GALLERY_TYPE,
+                                constants.MANAGED_IMAGE_TYPE],
+                       help="The type of image used to provision Windows "
+                       "agents.")
+        p.add_argument("--win-minion-image-id",
+                       help="The Azure managed image to be used for the "
+                       "Windows agents.")
         p.add_argument("--win-minion-gallery-image",
                        help="The Windows minion shared gallery. The "
                        "parameter shall be given as: "

--- a/e2e-runner/e2e_runner/constants.py
+++ b/e2e-runner/e2e_runner/constants.py
@@ -3,6 +3,9 @@ WINDOWS_ADMIN_USER = "azureuser"
 
 DEFAULT_KUBERNETES_VERSION = "v1.20.4"
 
+SHARED_IMAGE_GALLERY_TYPE = "shared-image-gallery"
+MANAGED_IMAGE_TYPE = "managed-image"
+
 FLANNEL_MODE_OVERLAY = "overlay"
 FLANNEL_MODE_L2BRIDGE = "host-gw"
 

--- a/e2e-runner/e2e_runner/deployer/capz/windows-agents.yaml.j2
+++ b/e2e-runner/e2e_runner/deployer/capz/windows-agents.yaml.j2
@@ -40,12 +40,17 @@ spec:
       sshPublicKey: {{ azure_ssh_public_key_b64 }}
       vmSize: {{ win_minion_size }}
       image:
+{%- if win_minion_image_type == "shared-image-gallery" %}
         sharedGallery:
           gallery: {{ win_minion_image_gallery }}
           subscriptionID: {{ azure_subscription_id }}
           resourceGroup: {{ win_minion_image_rg }}
           name: {{ win_minion_image_definition }}
           version: {{ win_minion_image_version }}
+{%- endif %}
+{%- if win_minion_image_type == "managed-image" %}
+        id: {{ win_minion_image_id }}
+{%- endif %}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
 kind: KubeadmConfigTemplate

--- a/image-builder/packer/azure-cbsl-init/README.md
+++ b/image-builder/packer/azure-cbsl-init/README.md
@@ -29,6 +29,8 @@ The current scripts support the following K8s Windows workers configurations:
     export AZURE_CLIENT_ID="<CLIENT_ID>"
     export AZURE_CLIENT_SECRET="<CLIENT_SECRET>"
 
+    export RESOURCE_GROUP_NAME="<TARGET_RESOURCE_GROUP_NAME>"
+
     export ACR_NAME="<ACR_NAME>"
     export ACR_USER_NAME="<ACR_USER_NAME>"
     export ACR_USER_PASSWORD="<ACR_USER_PASSWORD>"
@@ -65,4 +67,19 @@ The current scripts support the following K8s Windows workers configurations:
     packer build -var-file=windows-ltsc2019-docker-variables.json windows.json
     ```
 
-    When the `packer build` finishes, the image will be published to the Azure shared image gallery given in the variables file.
+    When the `packer build` finishes, the resulted Azure managed image is ready to be used.
+
+4. (Optional) Publish the managed image into a shared gallery, in case you want it to be used into multiple regions:
+
+    ```
+    IMAGE_ID="/subscriptions/<subscription ID>/resourceGroups/myResourceGroup/providers/Microsoft.Compute/images/myImage"
+
+    az sig image-version create \
+        --resource-group adtv-capz-win \
+        --gallery-name capz_gallery \
+        --gallery-image-definition ws-ltsc2019-containerd-cbsl-init \
+        --gallery-image-version 2021.02.19 \
+        --managed-image $IMAGE_ID \
+        --target-regions westeurope eastus2 westus2 southcentralus \
+        --replica-count 1
+    ```

--- a/image-builder/packer/azure-cbsl-init/k8s-node-setup/containerd/StartKubelet.ps1
+++ b/image-builder/packer/azure-cbsl-init/k8s-node-setup/containerd/StartKubelet.ps1
@@ -13,6 +13,7 @@ $cmd = ("C:\k\kubelet.exe $global:KubeletArgs " +
         "--resolv-conf=`"`" " +
         "--log-dir=/var/log/kubelet " +
         "--logtostderr=false " +
+        "--feature-gates=`"IPv6DualStack=false`" " +
         "--image-pull-progress-deadline=20m")
 
 Invoke-Expression $cmd

--- a/image-builder/packer/azure-cbsl-init/k8s-node-setup/docker/StartKubelet.ps1
+++ b/image-builder/packer/azure-cbsl-init/k8s-node-setup/docker/StartKubelet.ps1
@@ -19,6 +19,7 @@ $cmd = ("C:\k\kubelet.exe $global:KubeletArgs " +
         "--resolv-conf=`"`" " +
         "--log-dir=/var/log/kubelet " +
         "--logtostderr=false " +
+        "--feature-gates=`"IPv6DualStack=false`" " +
         "--image-pull-progress-deadline=20m")
 
 Invoke-Expression $cmd

--- a/image-builder/packer/azure-cbsl-init/windows-ltsc2019-containerd-variables.json
+++ b/image-builder/packer/azure-cbsl-init/windows-ltsc2019-containerd-variables.json
@@ -4,12 +4,6 @@
   "image_sku": "2019-Datacenter-Core-with-Containers-smalldisk-g2",
   "location": "westeurope",
   "vm_size": "Standard_D2s_v3",
-
-  "resource_group_name": "adtv-capz-win",
-  "container_runtime": "containerd",
-
-  "sig_name": "capz_gallery",
-  "sig_image_name": "ws-ltsc2019-containerd-cbsl-init",
-  "sig_image_version": "2021.02.19",
-  "sig_image_replication_regions": "westeurope,eastus2,westus2,southcentralus"
+  "image_name": "ws-ltsc2019-containerd-cbsl-init",
+  "container_runtime": "containerd"
 }

--- a/image-builder/packer/azure-cbsl-init/windows-ltsc2019-docker-variables.json
+++ b/image-builder/packer/azure-cbsl-init/windows-ltsc2019-docker-variables.json
@@ -4,12 +4,6 @@
   "image_sku": "2019-Datacenter-Core-with-Containers-smalldisk-g2",
   "location": "westeurope",
   "vm_size": "Standard_D2s_v3",
-
-  "resource_group_name": "adtv-capz-win",
-  "container_runtime": "docker",
-
-  "sig_name": "capz_gallery",
-  "sig_image_name": "ws-ltsc2019-docker-cbsl-init",
-  "sig_image_version": "2021.02.19",
-  "sig_image_replication_regions": "westeurope,eastus2,westus2,southcentralus"
+  "image_name": "ws-ltsc2019-docker-cbsl-init",
+  "container_runtime": "docker"
 }

--- a/image-builder/packer/azure-cbsl-init/windows-sac1909-containerd-variables.json
+++ b/image-builder/packer/azure-cbsl-init/windows-sac1909-containerd-variables.json
@@ -4,12 +4,6 @@
   "image_sku": "datacenter-core-1909-with-containers-smalldisk-g2",
   "location": "westeurope",
   "vm_size": "Standard_D2s_v3",
-
-  "resource_group_name": "adtv-capz-win",
-  "container_runtime": "containerd",
-
-  "sig_name": "capz_gallery",
-  "sig_image_name": "ws-1909-containerd-cbsl-init",
-  "sig_image_version": "2021.02.19",
-  "sig_image_replication_regions": "westeurope,eastus2,westus2,southcentralus"
+  "image_name": "ws-1909-containerd-cbsl-init",
+  "container_runtime": "containerd"
 }

--- a/image-builder/packer/azure-cbsl-init/windows-sac2004-containerd-variables.json
+++ b/image-builder/packer/azure-cbsl-init/windows-sac2004-containerd-variables.json
@@ -4,12 +4,6 @@
   "image_sku": "datacenter-core-2004-with-containers-smalldisk-g2",
   "location": "westeurope",
   "vm_size": "Standard_D2s_v3",
-
-  "resource_group_name": "adtv-capz-win",
-  "container_runtime": "containerd",
-
-  "sig_name": "capz_gallery",
-  "sig_image_name": "ws-2004-containerd-cbsl-init",
-  "sig_image_version": "2021.02.19",
-  "sig_image_replication_regions": "westeurope,eastus2,westus2,southcentralus"
+  "image_name": "ws-2004-containerd-cbsl-init",
+  "container_runtime": "containerd"
 }

--- a/image-builder/packer/azure-cbsl-init/windows.json
+++ b/image-builder/packer/azure-cbsl-init/windows.json
@@ -4,22 +4,16 @@
     "tenant_id": "{{ env `AZURE_TENANT_ID` }}",
     "client_id": "{{ env `AZURE_CLIENT_ID` }}",
     "client_secret": "{{ env `AZURE_CLIENT_SECRET` }}",
+    "resource_group_name": "{{ env `RESOURCE_GROUP_NAME` }}",
     "acr_name": "{{ env `ACR_NAME` }}",
     "acr_user_name": "{{ env `ACR_USER_NAME` }}",
     "acr_user_password": "{{ env `ACR_USER_PASSWORD` }}",
-
     "kubernetes_version": "{{ env `KUBERNETES_VERSION` }}",
 
-    "resource_group_name": "{{ user `resource_group_name` }}",
-
-    "sig_name": "{{ user `sig_name` }}",
-    "sig_image_name": "{{ user `sig_image_name` }}",
-    "sig_image_replication_regions": "{{ user `sig_image_replication_regions` }}",
-
+    "image_name": "{{ user `image_name` }}",
     "image_publisher": "{{ user `image_publisher` }}",
     "image_offer": "{{ user `image_offer` }}",
     "image_sku": "{{ user `image_sku` }}",
-
     "location": "{{ user `location` }}",
     "vm_size": "{{ user `vm_size` }}"
   },
@@ -33,17 +27,7 @@
       "client_id": "{{ user `client_id` }}",
       "client_secret": "{{ user `client_secret` }}",
 
-      "shared_image_gallery_destination": {
-        "resource_group": "{{ user `resource_group_name` }}",
-        "gallery_name": "{{ user `sig_name` }}",
-        "image_name": "{{ user `sig_image_name` }}",
-        "image_version": "{{ user `sig_image_version` }}",
-        "replication_regions": "{{ user `sig_image_replication_regions` }}"
-      },
-      "shared_image_gallery_timeout": "6h",
-      "shared_image_gallery_replica_count": 1,
-
-      "managed_image_name": "{{ user `sig_image_name` }}-{{ user `kubernetes_version` }}-{{ isotime | clean_resource_name }}",
+      "managed_image_name": "{{ user `image_name` }}-{{ user `kubernetes_version` }}-{{ isotime | clean_resource_name }}",
       "managed_image_resource_group_name": "{{ user `resource_group_name` }}",
 
       "os_type": "Windows",
@@ -53,7 +37,7 @@
 
       "vm_size": "{{ user `vm_size` }}",
       "location": "{{ user `location` }}",
-      "temp_resource_group_name": "build-{{ user `sig_image_name` }}-{{ isotime | clean_resource_name }}",
+      "temp_resource_group_name": "build-{{ user `image_name` }}-{{ isotime | clean_resource_name }}",
 
       "communicator": "winrm",
       "winrm_use_ssl": true,

--- a/prow-config.yaml
+++ b/prow-config.yaml
@@ -171,7 +171,7 @@ data:
             - "--win-minion-count=2"
             - "--enable-win-dsr=True"
             - "--container-runtime=docker"
-            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.02.19"
+            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.02.23"
             - "--cluster-name=capzflannel-l2br-$(BUILD_ID)"
 
     - cron: "0 3/12 * * *"
@@ -207,7 +207,7 @@ data:
             - "--win-minion-count=2"
             - "--enable-win-dsr=True"
             - "--container-runtime=docker"
-            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.02.19"
+            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.02.23"
             - "--cluster-name=capzflannel-ovrl-$(BUILD_ID)"
 
     - cron: "0 6/12 * * *"
@@ -245,7 +245,7 @@ data:
             - "--win-minion-count=2"
             - "--enable-win-dsr=True"
             - "--container-runtime=containerd"
-            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.02.19"
+            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.02.23"
             - "--cluster-name=capzctrd-$(BUILD_ID)"
 
     - cron: "0 9/12 * * *"
@@ -283,7 +283,7 @@ data:
             - "--win-minion-count=2"
             - "--enable-win-dsr=True"
             - "--container-runtime=containerd"
-            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.02.19"
+            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.02.23"
             - "--cluster-name=capzctrd-$(BUILD_ID)"
 
     - cron: "0 2 * * *"
@@ -321,7 +321,7 @@ data:
             - "--enable-win-dsr=True"
             - "--container-runtime=containerd"
             - "--base-container-image-tag=1909"
-            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-1909-containerd-cbsl-init:2021.02.19"
+            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-1909-containerd-cbsl-init:2021.02.23"
             - "--cluster-name=capzctrd1909-$(BUILD_ID)"
 
     - cron: "0 8 * * *"
@@ -359,7 +359,7 @@ data:
             - "--enable-win-dsr=True"
             - "--container-runtime=containerd"
             - "--base-container-image-tag=1909"
-            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-1909-containerd-cbsl-init:2021.02.19"
+            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-1909-containerd-cbsl-init:2021.02.23"
             - "--cluster-name=capzctrd1909-$(BUILD_ID)"
 
     - cron: "0 14 * * *"
@@ -398,7 +398,7 @@ data:
             - "--enable-win-dsr=True"
             - "--container-runtime=containerd"
             - "--base-container-image-tag=2004"
-            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.02.19"
+            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.02.23"
             - "--cluster-name=capzctrd2004-$(BUILD_ID)"
 
     - cron: "0 20 * * *"
@@ -437,5 +437,5 @@ data:
             - "--enable-win-dsr=True"
             - "--container-runtime=containerd"
             - "--base-container-image-tag=2004"
-            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.02.19"
+            - "--win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.02.23"
             - "--cluster-name=capzctrd2004-$(BUILD_ID)"


### PR DESCRIPTION
* Allow to create and use managed images directly
    * This will improve the smoke testing time for the new Packer images. And only images that are proven to be stable are published to the Azure shared gallery.
        * Do not publish to shared gallery via Packer. Have this as an optional step in the README.
        * Allow CAPZ deployments with Azure managed images.

* Disable IPv6DualStack feature gate
  * Make sure this is disabled for both kubelet and kube-proxy.

* Bump Azure images versions
