### PR TITLE
CI Updates

### DIFF
--- a/e2e-runner/Dockerfile
+++ b/e2e-runner/Dockerfile
@@ -38,6 +38,7 @@ ENV KUBECTL_PATH "/usr/local/bin/kubectl"
 
 WORKDIR /workspace
 
+ADD cleanup-azure-rgs.py /workspace
 ADD entrypoint.sh /workspace
 RUN chmod +x entrypoint.sh
 

--- a/e2e-runner/cleanup-azure-rgs.py
+++ b/e2e-runner/cleanup-azure-rgs.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+import logging
+import os
+
+from datetime import datetime
+
+import configargparse
+
+from azure.identity import ClientSecretCredential
+from azure.mgmt.resource import ResourceManagementClient
+
+
+logger = logging.getLogger("cleanup-azure-rgs")
+
+
+def setup_logging():
+    level = logging.DEBUG
+    logger.setLevel(level)
+    formatter = logging.Formatter(
+        "%(asctime)s %(levelname)s %(name)s: %(message)s",
+        datefmt="%m/%d/%Y %I:%M:%S %p",
+    )
+    stream = logging.StreamHandler()
+    stream.setLevel(level)
+    stream.setFormatter(formatter)
+    logger.addHandler(stream)
+
+
+def parse_args():
+    p = configargparse.get_argument_parser(
+        name="Azure resource groups cleanup script.")
+    p.add("--filter-tag-name", type=str,
+          default="ciName",
+          help="The filter tag name used when listing the resource groups.")
+    p.add("--filter-tag-value", type=str,
+          default="k8s-sig-win-networking-prow-flannel-e2e",
+          help="The filter tag value used when listing the resource groups.")
+    p.add("--max-age-minutes", type=int,
+          default=720,
+          help="The maximum allowed age of an Azure resource group (given in "
+          "minutes). If the resource group is older than this, then it's "
+          "deleted. To find out the age of a resource group, the tag "
+          "'creationTimestamp' is used.")
+    return p.parse_known_args()
+
+
+def get_azure_credentials():
+    required_env_vars = [
+        "AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET", "AZURE_TENANT_ID",
+        "AZURE_SUB_ID"
+    ]
+    for env_var in required_env_vars:
+        if not os.environ.get(env_var):
+            raise ValueError("Env variable %s is not set" % env_var)
+    credentials = ClientSecretCredential(
+        client_id=os.environ["AZURE_CLIENT_ID"],
+        client_secret=os.environ["AZURE_CLIENT_SECRET"],
+        tenant_id=os.environ["AZURE_TENANT_ID"])
+    subscription_id = os.environ["AZURE_SUB_ID"]
+    return credentials, subscription_id
+
+
+def main():
+    setup_logging()
+    args = parse_args()[0]
+
+    credentials, subscription_id = get_azure_credentials()
+    client = ResourceManagementClient(credentials, subscription_id)
+
+    filter = "tagName eq '{}' and tagValue eq '{}'".format(
+        args.filter_tag_name, args.filter_tag_value)
+    logger.info("Listing resource groups filtered by the given tag.")
+    for rg in client.resource_groups.list(filter=filter):
+        logger.info("Found resource group: %s.", rg.name)
+
+        creation_timestamp = rg.tags.get('creationTimestamp')
+        if not creation_timestamp:
+            logger.warning("The resource group doesn't have the creation "
+                           "timestamp tag. Skipping it.")
+            continue
+
+        creation_date = datetime.fromisoformat(creation_timestamp)
+        now_date = datetime.fromisoformat(datetime.utcnow().isoformat())
+        age_minutes = (now_date - creation_date).seconds / 60
+
+        if age_minutes > args.max_age_minutes:
+            logger.info("Deleting the resource group.")
+            client.resource_groups.begin_delete(rg.name)
+        else:
+            logger.info(
+                "Resource group age (%s minutes) is not bigger than "
+                "maximum allowed age (%s minutes).", age_minutes,
+                args.max_age_minutes)
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import time
 
+from datetime import datetime
 from distutils.util import strtobool
 
 import sh
@@ -36,7 +37,22 @@ class CapzFlannelCI(base.CI):
             opts,
             flannel_mode=self.opts.flannel_mode,
             container_runtime=self.opts.container_runtime,
-            kubernetes_version=self.kubernetes_version)
+            kubernetes_version=self.kubernetes_version,
+            resource_group_tags=self.resource_group_tags)
+
+    @property
+    def resource_group_tags(self):
+        tags = {
+            'creationTimestamp': datetime.utcnow().isoformat(),
+            'ciName': 'k8s-sig-win-networking-prow-flannel-e2e',
+        }
+        build_id = os.environ.get('BUILD_ID')
+        if build_id:
+            tags['buildID'] = build_id
+        job_name = os.environ.get('JOB_NAME')
+        if job_name:
+            tags['jobName'] = job_name
+        return tags
 
     def build(self, bins_to_build):
         builder_mapping = {

--- a/e2e-runner/e2e_runner/ci/capz_flannel/flannel/cni/containerd-l2bridge-windows.yaml.j2
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/flannel/cni/containerd-l2bridge-windows.yaml.j2
@@ -1,7 +1,7 @@
   cni-conf.json: |
     {
       "name": "cbr0",
-      "cniVersion": "0.2.0",
+      "cniVersion": "0.3.0",
       "type": "flannel",
       "capabilities": {
         "dns": true
@@ -11,14 +11,6 @@
         "master": "eth0",
         "optionalFlags": {
           "forceBridgeGateway": true
-        },
-        "dns": {
-          "nameservers": [
-            "10.96.0.10"
-          ],
-          "search": [
-            "svc.cluster.local"
-          ]
         },
         "AdditionalArgs": [
           {

--- a/e2e-runner/e2e_runner/ci/capz_flannel/flannel/cni/containerd-overlay-windows.yaml.j2
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/flannel/cni/containerd-overlay-windows.yaml.j2
@@ -1,21 +1,13 @@
   cni-conf.json: |
     {
       "name": "vxlan0",
-      "cniVersion": "0.2.0",
+      "cniVersion": "0.3.0",
       "type": "flannel",
       "capabilities": {
         "dns": true
       },
       "delegate": {
         "type": "sdnoverlay",
-        "dns": {
-          "nameservers": [
-            "10.96.0.10"
-          ],
-          "search": [
-            "svc.cluster.local"
-          ]
-        },
         "AdditionalArgs": [
           {
             "Name": "EndpointPolicy",

--- a/e2e-runner/e2e_runner/ci/capz_flannel/flannel/cni/docker-l2bridge-windows.yaml.j2
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/flannel/cni/docker-l2bridge-windows.yaml.j2
@@ -1,21 +1,13 @@
   cni-conf.json: |
     {
       "name": "cbr0",
-      "cniVersion": "0.2.0",
+      "cniVersion": "0.3.0",
       "type": "flannel",
       "capabilities": {
         "dns": true
       },
       "delegate": {
         "type": "win-bridge",
-        "dns": {
-          "nameservers": [
-            "10.96.0.10"
-          ],
-          "search": [
-            "svc.cluster.local"
-          ]
-        },
         "policies": [
           {
             "Name": "EndpointPolicy",

--- a/e2e-runner/e2e_runner/ci/capz_flannel/flannel/cni/docker-overlay-windows.yaml.j2
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/flannel/cni/docker-overlay-windows.yaml.j2
@@ -1,21 +1,13 @@
   cni-conf.json: |
     {
       "name": "vxlan0",
-      "cniVersion": "0.2.0",
+      "cniVersion": "0.3.0",
       "type": "flannel",
       "capabilities": {
         "dns": true
       },
       "delegate": {
         "type": "win-overlay",
-        "dns": {
-          "nameservers": [
-            "10.96.0.10"
-          ],
-          "search": [
-            "svc.cluster.local"
-          ]
-        },
         "policies": [
           {
             "Name": "EndpointPolicy",

--- a/e2e-runner/e2e_runner/cli/run_ci.py
+++ b/e2e-runner/e2e_runner/cli/run_ci.py
@@ -18,13 +18,13 @@ class RunCI(Command):
 
         p.add_argument('--artifacts-directory', default='/tmp/ci_artifacts',
                        help='Local path to place all the artifacts.')
-        p.add_argument('--install-patch', action='append',
+        p.add_argument('--install-patch', action='append', default=[],
                        help='URLs of KBs to install on Windows nodes.')
         p.add_argument('--up', type=utils.str2bool, default=False,
                        help='Deploy test cluster.')
         p.add_argument('--down', type=utils.str2bool, default=False,
                        help='Destroy cluster on finish.')
-        p.add_argument('--build', action='append',
+        p.add_argument('--build', action='append', default=[],
                        choices=['k8sbins', 'containerdbins',
                                 'containerdshim', 'sdncnibins'],
                        help='Binaries to build.')
@@ -154,11 +154,8 @@ class RunCI(Command):
         ci = factory.get_ci(args.ci)(args)
 
         try:
-            if args.build is not None:
-                ci.build(args.build)
-
-            if args.install_patch is not None:
-                ci.set_patches(" ".join(args.install_patch))
+            ci.build(args.build)
+            ci.set_patches(args.install_patch)
 
             if args.up is True:
                 ci.up()

--- a/e2e-runner/e2e_runner/deployer/capz/capz.py
+++ b/e2e-runner/e2e_runner/deployer/capz/capz.py
@@ -1061,7 +1061,7 @@ class CAPZProvisioner(base.Deployer):
         ])
 
     def _set_azure_variables(self):
-        # Define the requried env variables list
+        # Define the required env variables list
         required_env_vars = [
             "AZURE_SUBSCRIPTION_ID", "AZURE_TENANT_ID", "AZURE_CLIENT_ID",
             "AZURE_CLIENT_SECRET", "AZURE_SSH_PUBLIC_KEY"

--- a/e2e-runner/e2e_runner/deployer/capz/capz.py
+++ b/e2e-runner/e2e_runner/deployer/capz/capz.py
@@ -31,7 +31,8 @@ from e2e_runner import (
 class CAPZProvisioner(base.Deployer):
     def __init__(self, opts, container_runtime="docker",
                  flannel_mode=constants.FLANNEL_MODE_OVERLAY,
-                 kubernetes_version=constants.DEFAULT_KUBERNETES_VERSION):
+                 kubernetes_version=constants.DEFAULT_KUBERNETES_VERSION,
+                 resource_group_tags={}):
         super(CAPZProvisioner, self).__init__()
 
         self.e2e_runner_dir = str(Path(__file__).parents[2])
@@ -56,6 +57,7 @@ class CAPZProvisioner(base.Deployer):
         self.control_plane_subnet_cidr_block = \
             opts.control_plane_subnet_cidr_block
         self.node_subnet_cidr_block = opts.node_subnet_cidr_block
+        self.resource_group_tags = resource_group_tags
 
         self.win_minion_count = opts.win_minion_count
         self.win_minion_size = opts.win_minion_size
@@ -657,9 +659,13 @@ class CAPZProvisioner(base.Deployer):
 
     def _create_resource_group(self):
         self.logging.info("Creating Azure resource group")
+        resource_group_params = {
+            'location': self.azure_location,
+            'tags': self.resource_group_tags,
+        }
         self.resource_mgmt_client.resource_groups.create_or_update(
             self.cluster_name,
-            {'location': self.azure_location})
+            resource_group_params)
 
         sleep_time = 5
         max_wait = 600  # Maximum 10 mins wait time

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -11,6 +11,21 @@ periodics:
     - image: e2eteam/kube-backup:latest
       imagePullPolicy: Always
 
+- name: clean-azure-resource-groups
+  interval: 30m
+  always_run: true
+  labels:
+    preset-prod-azure-account: "true"
+  spec:
+    containers:
+    - image: e2eteam/k8s-e2e-runner:latest
+      imagePullPolicy: Always
+      command:
+        - /workspace/cleanup-azure-rgs.py
+      args:
+        # Cleanup resource groups older than 12h.
+        - --max-age-minutes=720
+
 - name: ci-kubernetes-e2e-flannel-l2bridge-master-windows
   cron: "0 0/12 * * *"
   always_run: true


### PR DESCRIPTION
* Add tags to the Azure RGs.
* Cleanup the bootstrap VM early. Once the CAPZ cluster is deployed, the bootstrap VM is safe to be deleted.
* Bump `cniVersion` to `0.3.0`. Also remove the explicit DNS servers list config, since it's not required with `"capabilities": {"dns": true}`.
* Add job to cleanup orphan Azure RGs. This is meant to delete orphan CI resource groups that are left when something went wrong with the testing prowjobs. Also, fixed a small typo.