### PR TITLE
Fix host-gw CNI deployments and other CI updates

### DIFF
--- a/e2e-runner/Dockerfile
+++ b/e2e-runner/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 ARG GO_VERSION=1.16
-ARG CAPI_VERSION=v0.3.13
+ARG CAPI_VERSION=v0.3.15
 ARG KUBECTL_VERSION=v1.20.5
 
 # Install system APT packages & dependencies

--- a/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
@@ -79,6 +79,7 @@ class CapzFlannelCI(base.CI):
         self.deployer.up()
         self.deployer.wait_for_agents(check_nodes_ready=False, timeout=7200)
         if self.opts.flannel_mode == constants.FLANNEL_MODE_L2BRIDGE:
+            self.deployer.connect_agents_to_controlplane_subnet()
             self.deployer.enable_ip_forwarding()
 
         self.deployer.setup_ssh_config()

--- a/e2e-runner/e2e_runner/ci/capz_flannel/flannel/kube-flannel-windows.Dockerfile
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/flannel/kube-flannel-windows.Dockerfile
@@ -12,6 +12,6 @@ RUN mkdir -force C:\k\flannel; \
     curl.exe -LO https://github.com/coreos/flannel/releases/download/${env:flannelVersion}/flanneld.exe
 
 RUN mkdir C:\utils; \
-    curl.exe -Lo C:\utils\wins.exe https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe; \
-    curl.exe -Lo C:\utils\yq.exe https://github.com/mikefarah/yq/releases/download/2.4.1/yq_windows_amd64.exe; \
+    curl.exe -Lo C:\utils\wins.exe https://github.com/rancher/wins/releases/download/v0.1.0/wins.exe; \
+    curl.exe -Lo C:\utils\yq.exe https://github.com/mikefarah/yq/releases/download/v4.6.3/yq_windows_amd64.exe; \
     "[Environment]::SetEnvironmentVariable('PATH', $env:PATH + ';C:\utils', [EnvironmentVariableTarget]::Machine)"

--- a/e2e-runner/e2e_runner/ci/capz_flannel/flannel/kube-flannel-windows.yaml.j2
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/flannel/kube-flannel-windows.yaml.j2
@@ -51,7 +51,12 @@ data:
     cp -force /var/run/secrets/kubernetes.io/serviceaccount/* /host/k/flannel/var/run/secrets/kubernetes.io/serviceaccount/
 
   run.ps1: |
-    wins cli process run --path /k/flannel/flanneld.exe --args "--kube-subnet-mgr --ip-masq --kubeconfig-file /k/flannel/kubeconfig.yml" --envs "POD_NAME=$env:POD_NAME POD_NAMESPACE=$env:POD_NAMESPACE"
+    $ErrorActionPreference = "Stop"
+
+    mkdir -force /host/k/flannel
+    cp -force /k/flannel/flanneld.exe /host/k/flannel/
+
+    wins cli process run --path /k/flannel/flanneld.exe --envs "POD_NAME=$env:POD_NAME POD_NAMESPACE=$env:POD_NAMESPACE" --args "--kube-subnet-mgr --ip-masq --kubeconfig-file /k/flannel/kubeconfig.yml"
 
 {% include ("cni/" + container_runtime + "-" + mode + "-windows.yaml.j2") %}
 
@@ -126,6 +131,8 @@ spec:
         volumeMounts:
         - name: wins
           mountPath: \\.\pipe\rancher_wins
+        - name: host
+          mountPath: /host
         - name: flannel-windows-cfg
           mountPath: /etc/kube-flannel-windows/
         env:

--- a/e2e-runner/e2e_runner/ci/capz_flannel/flannel/kube-flannel-windows.yaml.j2
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/flannel/kube-flannel-windows.yaml.j2
@@ -17,8 +17,8 @@ data:
     mkdir -force /host/k/flannel/var/run/secrets/kubernetes.io/serviceaccount
 
     $cniJson = get-content /etc/kube-flannel-windows/cni-conf.json | ConvertFrom-Json
-    $serviceSubnet = yq r /etc/kubeadm-config/ClusterConfiguration networking.serviceSubnet
-    $podSubnet = yq r /etc/kubeadm-config/ClusterConfiguration networking.podSubnet
+    $serviceSubnet = yq eval '.networking.serviceSubnet' /etc/kubeadm-config/ClusterConfiguration
+    $podSubnet = yq eval '.networking.podSubnet' /etc/kubeadm-config/ClusterConfiguration
     $networkJson = wins cli net get | ConvertFrom-Json
 
 {%- if container_runtime == "containerd" and mode == "overlay" %}

--- a/e2e-runner/e2e_runner/ci/capz_flannel/flannel/kube-flannel.yaml.j2
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/flannel/kube-flannel.yaml.j2
@@ -200,9 +200,6 @@ spec:
         args:
         - --ip-masq
         - --kube-subnet-mgr
-{%- if flannel_mode == "host-gw" %}
-        - --iface=eth1
-{%- endif %}
         resources:
           requests:
             cpu: "100m"

--- a/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/kube-proxy-windows.Dockerfile
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/kube-proxy-windows.Dockerfile
@@ -12,6 +12,6 @@ RUN mkdir -force C:\k\kube-proxy; \
     curl.exe --fail -sLO https://dl.k8s.io/${env:k8sVersion}/bin/windows/amd64/kube-proxy.exe
 
 RUN mkdir C:\utils; \
-    curl.exe --fail -sLo C:\utils\wins.exe https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe; \
-    curl.exe --fail -sLo C:\utils\yq.exe https://github.com/mikefarah/yq/releases/download/2.4.1/yq_windows_amd64.exe; \
+    curl.exe --fail -sLo C:\utils\wins.exe https://github.com/rancher/wins/releases/download/v0.1.0/wins.exe; \
+    curl.exe --fail -sLo C:\utils\yq.exe https://github.com/mikefarah/yq/releases/download/v4.6.3/yq_windows_amd64.exe; \
     "[Environment]::SetEnvironmentVariable('PATH', $env:PATH + ';C:\utils', [EnvironmentVariableTarget]::Machine)"

--- a/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/kube-proxy-windows.yaml.j2
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/kube-proxy-windows.yaml.j2
@@ -17,18 +17,18 @@ data:
 
     $networkName = (Get-Content /host/etc/cni/net.d/10-flannel.conf | ConvertFrom-Json).name
 
-    yq w -i /host/var/lib/kube-proxy/config.conf winkernel.networkName $networkName
+    yq eval -i ".winkernel.networkName = `"`"${networkName}`"`"" /host/var/lib/kube-proxy/config.conf
 {%- if flannel_mode == "overlay" %}
     $sourceVip = ((cat /host/k/sourceVip.json | ConvertFrom-Json).ip4.ip -split '/')[0]
-    yq w -i /host/var/lib/kube-proxy/config.conf winkernel.sourceVip $sourceVip
-    yq w -i /host/var/lib/kube-proxy/config.conf featureGates.WinOverlay true
+    yq eval -i ".winkernel.sourceVip = `"`"${sourceVip}`"`"" /host/var/lib/kube-proxy/config.conf
+    yq eval -i '.featureGates.WinOverlay = true' /host/var/lib/kube-proxy/config.conf
 {%- endif %}
 {%- if enable_win_dsr == "true" %}
-    yq w -i /host/var/lib/kube-proxy/config.conf winkernel.enableDSR {{ enable_win_dsr }}
-    yq w -i /host/var/lib/kube-proxy/config.conf featureGates.WinDSR {{ enable_win_dsr }}
+    yq eval -i '.winkernel.enableDSR = true' /host/var/lib/kube-proxy/config.conf
+    yq eval -i '.featureGates.WinDSR = true' /host/var/lib/kube-proxy/config.conf
 {%- endif %}
-    yq w -i /host/var/lib/kube-proxy/config.conf featureGates.IPv6DualStack {{ enable_ipv6dualstack }}
-    yq w -i /host/var/lib/kube-proxy/config.conf mode "kernelspace"
+    yq eval -i '.featureGates.IPv6DualStack = {{ enable_ipv6dualstack }}' /host/var/lib/kube-proxy/config.conf
+    yq eval -i '.mode = ""kernelspace""' /host/var/lib/kube-proxy/config.conf
 
   run.ps1: |
     $ErrorActionPreference = "Stop"

--- a/e2e-runner/e2e_runner/constants.py
+++ b/e2e-runner/e2e_runner/constants.py
@@ -18,5 +18,5 @@ CONTAINERD_BINS_LOCATION = "bin"
 CONTAINERD_SHIM_DIR = "./cmd/containerd-shim-runhcs-v1"
 CONTAINERD_SHIM_BIN = "containerd-shim-runhcs-v1.exe"
 
-CAPI_VERSION = "v0.3.13"
-CAPZ_PROVIDER_VERSION = "v0.4.11"
+CAPI_VERSION = "v0.3.15"
+CAPZ_PROVIDER_VERSION = "v0.4.13"

--- a/e2e-runner/requirements.txt
+++ b/e2e-runner/requirements.txt
@@ -8,3 +8,4 @@ jinja2
 sh
 property-cached
 pycryptodome
+tenacity

--- a/image-builder/packer/azure-cbsl-init/k8s-node-setup/common.ps1
+++ b/image-builder/packer/azure-cbsl-init/k8s-node-setup/common.ps1
@@ -206,18 +206,3 @@ function Install-CNI {
     Start-FileDownload "https://capzwin.blob.core.windows.net/bin/sdnoverlay.exe" "$OPT_DIR\cni\bin\sdnoverlay.exe"
     Start-FileDownload "https://capzwin.blob.core.windows.net/bin/sdnbridge.exe" "$OPT_DIR\cni\bin\sdnbridge.exe"
 }
-
-function Start-EnvironmentValidation {
-    $requiredEnvVars = @(
-        "KUBERNETES_VERSION",
-        "ACR_NAME",
-        "ACR_USER_NAME",
-        "ACR_USER_PASSWORD"
-    )
-    foreach($envVar in $requiredEnvVars) {
-        $var = Get-Item "env:${envVar}" -ErrorAction SilentlyContinue
-        if(!$var) {
-            Throw "Required environment variable $envVar is not set."
-        }
-    }
-}

--- a/image-builder/packer/azure-cbsl-init/k8s-node-setup/common.ps1
+++ b/image-builder/packer/azure-cbsl-init/k8s-node-setup/common.ps1
@@ -143,7 +143,7 @@ function Install-Kubelet {
 
     Start-FileDownload "https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubelet.exe" "$KUBERNETES_DIR\kubelet.exe"
     Start-FileDownload "https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubeadm.exe" "$KUBERNETES_DIR\kubeadm.exe"
-    Start-FileDownload "https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe" "$KUBERNETES_DIR\wins.exe"
+    Start-FileDownload "https://github.com/rancher/wins/releases/download/v0.1.0/wins.exe" "$KUBERNETES_DIR\wins.exe"
 
     Write-Output "Registering wins Windows service"
     wins.exe srv app run --register

--- a/image-builder/packer/azure-cbsl-init/windows.json
+++ b/image-builder/packer/azure-cbsl-init/windows.json
@@ -89,13 +89,9 @@
       "elevated_user": "packer",
       "elevated_password": "{{.WinRMPassword}}",
       "type": "powershell",
-      "environment_vars": [
-        "KUBERNETES_VERSION={{ user `kubernetes_version` }}",
-        "ACR_NAME={{ user `acr_name` }}",
-        "ACR_USER_NAME={{ user `acr_user_name` }}",
-        "ACR_USER_PASSWORD={{ user `acr_user_password` }}"
-      ],
-      "inline": ["C:\\k8s-node-setup\\{{ user `container_runtime` }}\\PrepareNode.ps1"]
+      "inline": [
+        "C:\\k8s-node-setup\\{{ user `container_runtime` }}\\PrepareNode.ps1 -KubernetesVersion {{ user `kubernetes_version` }} -AcrName {{ user `acr_name` }} -AcrUserName {{ user `acr_user_name` }} -AcrUserPassword {{ user `acr_user_password` }}"
+      ]
     },
     {
       "elevated_user": "packer",

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -27,7 +27,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.03.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.04.03
         - --cluster-name=capzflannel-l2br-$(BUILD_ID)
 
 - name: ci-kubernetes-e2e-flannel-overlay-master-windows
@@ -58,7 +58,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.03.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.04.03
         - --cluster-name=capzflannel-ovrl-$(BUILD_ID)
 
 - name: ci-kubernetes-e2e-sdnbridge-ctrd-master-windows
@@ -91,7 +91,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.03.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.04.03
         - --cluster-name=capzctrd-$(BUILD_ID)
 
 - name: ci-kubernetes-e2e-sdnoverlay-ctrd-master-windows
@@ -124,7 +124,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.03.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.04.03
         - --cluster-name=capzctrd-$(BUILD_ID)
 
 - name: containerd-windows-sac1909-sdnbridge
@@ -157,7 +157,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=1909
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-1909-containerd-cbsl-init:2021.03.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-1909-containerd-cbsl-init:2021.04.03
         - --cluster-name=capzctrd1909-$(BUILD_ID)
 
 - name: containerd-windows-sac1909-sdnoverlay
@@ -190,7 +190,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=1909
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-1909-containerd-cbsl-init:2021.03.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-1909-containerd-cbsl-init:2021.04.03
         - --cluster-name=capzctrd1909-$(BUILD_ID)
 
 - name: containerd-windows-sac2004-sdnbridge
@@ -224,7 +224,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=2004
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.03.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.04.03
         - --cluster-name=capzctrd2004-$(BUILD_ID)
 
 - name: containerd-windows-sac2004-sdnoverlay
@@ -258,7 +258,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=2004
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.03.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.04.03
         - --cluster-name=capzctrd2004-$(BUILD_ID)
 
 - name: ci-kubernetes-e2e-winbridge-docker-dsr-disabled-master-windows
@@ -289,7 +289,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=False
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.03.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.04.03
         - --cluster-name=capzdocker-ltsc2019-$(BUILD_ID)
 
 - name: ci-kubernetes-e2e-winoverlay-docker-dsr-disabled-master-windows
@@ -320,7 +320,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=False
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.03.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.04.03
         - --cluster-name=capzdocker-ltsc2019-$(BUILD_ID)
 
 - name: ci-kubernetes-e2e-sdnbridge-ctrd-stable-windows
@@ -352,7 +352,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.03.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.04.03
         - --cluster-name=capzctrd-ltsc2019-$(BUILD_ID)
 
 - name: ci-kubernetes-e2e-sdnoverlay-ctrd-stable-windows
@@ -384,5 +384,5 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.03.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.04.03
         - --cluster-name=capzctrd-ltsc2019-$(BUILD_ID)


### PR DESCRIPTION
* Bump CAPI and CAPZ versions

* Bump wins and yq deps versions

* Fix kube-flannel Windows daemonset

  Before `wins cli process run` is executed, we need the `flanneld.exe`
  on the host.

* Packer: use script parameters instead of env.
  Packer builds often failed because the env is not properly set.

* Fix host-gw CNI deployments.

  The default Kubernetes `10.96.0.1` cluster IP doesn't work
  properly with multi-nic configuration on the control-plane VM.

  So, in order to have all the machines on the same L2 segment
  (required for the `host-gw` deployments), we connect the K8s
  agents to the same subnet as control-plane. This removes the
  multi-nic workaround for the control-plane VM.

* Bump Azure images versions