### PR TITLE
Use preset-windows-private-registry-cred for master jobs

### DIFF
--- a/e2e-runner/e2e_runner/cli/run_ci.py
+++ b/e2e-runner/e2e_runner/cli/run_ci.py
@@ -55,7 +55,8 @@ class RunCI(Command):
 
         p.add_argument('--k8s-repo',
                        default='https://github.com/kubernetes/kubernetes')
-        p.add_argument('--k8s-branch', default='master')
+        p.add_argument('--k8s-branch',
+                       default=constants.DEFAULT_KUBERNETES_VERSION)
 
         p.add_argument('--containerd-repo',
                        default='https://github.com/containerd/containerd')

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -6,6 +6,7 @@ periodics:
   labels:
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
+    preset-windows-private-registry-cred: "true"
   spec:
     containers:
     - image: e2eteam/k8s-e2e-runner:latest
@@ -37,6 +38,7 @@ periodics:
   labels:
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
+    preset-windows-private-registry-cred: "true"
   spec:
     containers:
     - image: e2eteam/k8s-e2e-runner:latest
@@ -68,6 +70,7 @@ periodics:
   labels:
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
+    preset-windows-private-registry-cred: "true"
   spec:
     containers:
     - image: e2eteam/k8s-e2e-runner:latest
@@ -101,6 +104,7 @@ periodics:
   labels:
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
+    preset-windows-private-registry-cred: "true"
   spec:
     containers:
     - image: e2eteam/k8s-e2e-runner:latest
@@ -268,6 +272,7 @@ periodics:
   labels:
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
+    preset-windows-private-registry-cred: "true"
   spec:
     containers:
     - image: e2eteam/k8s-e2e-runner:latest
@@ -299,6 +304,7 @@ periodics:
   labels:
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
+    preset-windows-private-registry-cred: "true"
   spec:
     containers:
     - image: e2eteam/k8s-e2e-runner:latest

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -22,6 +22,7 @@ periodics:
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
         - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|Kubectl.logs.should.be.able.to.retrieve.and.filter.logs|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+        - --k8s-branch=master
         - --build=k8sbins
         - capz_flannel
         - --flannel-mode=host-gw
@@ -54,6 +55,7 @@ periodics:
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
         - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|Kubectl.logs.should.be.able.to.retrieve.and.filter.logs|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+        - --k8s-branch=master
         - --build=k8sbins
         - capz_flannel
         - --flannel-mode=overlay
@@ -86,6 +88,7 @@ periodics:
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
         - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|device.plugin.for.Windows
+        - --k8s-branch=master
         - --build=k8sbins
         - --build=containerdbins
         - --build=containerdshim
@@ -120,6 +123,7 @@ periodics:
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
         - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|device.plugin.for.Windows
+        - --k8s-branch=master
         - --build=k8sbins
         - --build=containerdbins
         - --build=containerdshim
@@ -154,7 +158,6 @@ periodics:
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
         - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|device.plugin.for.Windows
         - --build=sdncnibins
-        - --k8s-branch=v1.20.5
         - capz_flannel
         - --flannel-mode=host-gw
         - --win-minion-count=2
@@ -187,7 +190,6 @@ periodics:
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
         - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|device.plugin.for.Windows
         - --build=sdncnibins
-        - --k8s-branch=v1.20.5
         - capz_flannel
         - --flannel-mode=overlay
         - --win-minion-count=2
@@ -221,7 +223,6 @@ periodics:
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
         - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|device.plugin.for.Windows
         - --build=sdncnibins
-        - --k8s-branch=v1.20.5
         - capz_flannel
         - --flannel-mode=host-gw
         - --win-minion-count=2
@@ -255,7 +256,6 @@ periodics:
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
         - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|device.plugin.for.Windows
         - --build=sdncnibins
-        - --k8s-branch=v1.20.5
         - capz_flannel
         - --flannel-mode=overlay
         - --win-minion-count=2
@@ -288,6 +288,7 @@ periodics:
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
         - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|Kubectl.logs.should.be.able.to.retrieve.and.filter.logs|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+        - --k8s-branch=master
         - --build=k8sbins
         - capz_flannel
         - --flannel-mode=host-gw
@@ -320,6 +321,7 @@ periodics:
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
         - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|Kubectl.logs.should.be.able.to.retrieve.and.filter.logs|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+        - --k8s-branch=master
         - --build=k8sbins
         - capz_flannel
         - --flannel-mode=overlay
@@ -352,7 +354,6 @@ periodics:
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
         - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|device.plugin.for.Windows
         - --build=sdncnibins
-        - --k8s-branch=v1.20.5
         - capz_flannel
         - --flannel-mode=host-gw
         - --win-minion-count=2
@@ -384,7 +385,6 @@ periodics:
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
         - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|device.plugin.for.Windows
         - --build=sdncnibins
-        - --k8s-branch=v1.20.5
         - capz_flannel
         - --flannel-mode=overlay
         - --win-minion-count=2


### PR DESCRIPTION
* Use `preset-windows-private-registry-cred` for K8s `master` branch jobs.
  There is a test on K8s `master` branch that uses the private registry.

* Use stable K8s version as default K8s branch param
  Instead of using `master` as default value for `--k8s-branch`,
  we use the stable K8s version to avoid changing the job config
  every time the stable K8s version is updated.