### PR TITLE
Update tests focus / skip regexes

### DIFF
--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -20,8 +20,8 @@ periodics:
         - --parallel-test-nodes=4
         - --repo-list=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-master
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
-        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
-        - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|Kubectl.logs.should.be.able.to.retrieve.and.filter.logs|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
         - --k8s-branch=master
         - --build=k8sbins
         - capz_flannel
@@ -53,8 +53,8 @@ periodics:
         - --parallel-test-nodes=4
         - --repo-list=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-master
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
-        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
-        - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|Kubectl.logs.should.be.able.to.retrieve.and.filter.logs|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
         - --k8s-branch=master
         - --build=k8sbins
         - capz_flannel
@@ -86,8 +86,8 @@ periodics:
         - --parallel-test-nodes=4
         - --repo-list=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-master
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
-        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
-        - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|device.plugin.for.Windows
+        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows
         - --k8s-branch=master
         - --build=k8sbins
         - --build=containerdbins
@@ -121,8 +121,8 @@ periodics:
         - --parallel-test-nodes=4
         - --repo-list=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-master
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
-        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
-        - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|device.plugin.for.Windows
+        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows
         - --k8s-branch=master
         - --build=k8sbins
         - --build=containerdbins
@@ -155,8 +155,8 @@ periodics:
         - --parallel-test-nodes=4
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-stable.yaml
-        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
-        - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|device.plugin.for.Windows
+        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows
         - --build=sdncnibins
         - capz_flannel
         - --flannel-mode=host-gw
@@ -187,8 +187,8 @@ periodics:
         - --parallel-test-nodes=4
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-stable.yaml
-        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
-        - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|device.plugin.for.Windows
+        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows
         - --build=sdncnibins
         - capz_flannel
         - --flannel-mode=overlay
@@ -220,8 +220,8 @@ periodics:
         - --parallel-test-nodes=4
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-2004
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-stable.yaml
-        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
-        - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|device.plugin.for.Windows
+        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows
         - --build=sdncnibins
         - capz_flannel
         - --flannel-mode=host-gw
@@ -253,8 +253,8 @@ periodics:
         - --parallel-test-nodes=4
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-2004
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-stable.yaml
-        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
-        - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|device.plugin.for.Windows
+        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows
         - --build=sdncnibins
         - capz_flannel
         - --flannel-mode=overlay
@@ -286,8 +286,8 @@ periodics:
         - --parallel-test-nodes=4
         - --repo-list=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-master
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
-        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
-        - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|Kubectl.logs.should.be.able.to.retrieve.and.filter.logs|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
         - --k8s-branch=master
         - --build=k8sbins
         - capz_flannel
@@ -319,8 +319,8 @@ periodics:
         - --parallel-test-nodes=4
         - --repo-list=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-master
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
-        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
-        - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|Kubectl.logs.should.be.able.to.retrieve.and.filter.logs|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
         - --k8s-branch=master
         - --build=k8sbins
         - capz_flannel
@@ -351,8 +351,8 @@ periodics:
         - --parallel-test-nodes=4
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-stable.yaml
-        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
-        - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|device.plugin.for.Windows
+        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows
         - --build=sdncnibins
         - capz_flannel
         - --flannel-mode=host-gw
@@ -382,8 +382,8 @@ periodics:
         - --parallel-test-nodes=4
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-stable.yaml
-        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-scheduling\].SchedulerPreemption
-        - --test-skip-regex=Aggregator.*API.*Conformance|\[LinuxOnly\]|\[Serial\]|GMSA|device.plugin.for.Windows
+        - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows
         - --build=sdncnibins
         - capz_flannel
         - --flannel-mode=overlay


### PR DESCRIPTION
This is a follow-up PR to the upstream change from: https://github.com/kubernetes/test-infra/pull/21156

Also, disabled `[Slow]` tests as they are meant to be executed
with `[Serial]` tests (which were disabled already).