### PR TITLE
Decrease tests timeout to 8h

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1,7 +1,7 @@
 plank:
   default_decoration_configs:
     "*":
-      timeout: 12h
+      timeout: 8h
       grace_period: 15m
       gcs_configuration:
         bucket: gs://k8s-ovn

--- a/prow/cronjobs/cleanup-azure-rgs.yaml
+++ b/prow/cronjobs/cleanup-azure-rgs.yaml
@@ -21,8 +21,8 @@ spec:
             command:
             - /workspace/cleanup-azure-rgs.py
             args:
-            # Cleanup resource groups older than 12h.
-            - --max-age-minutes=720
+            # Cleanup resource groups older than 8h.
+            - --max-age-minutes=480
             env:
             - name: AZURE_CLIENT_ID
               valueFrom:


### PR DESCRIPTION
This should cover the jobs' worst execution times.