### PR TITLE
Remove terminated_pod_ttl config

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -19,7 +19,6 @@ plank:
 sinker:
   max_prowjob_age: 48h
   max_pod_age: 48h
-  terminated_pod_ttl: 30m
 
 prowjob_namespace: default
 pod_namespace: test-pods


### PR DESCRIPTION
The `max_pod_age` will be used, no matter if the pod is
terminated or not.