### PR TITLE
Enable IPv6DualStack for Docker l2bridge

### DIFF
--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -28,6 +28,7 @@ periodics:
         - --flannel-mode=host-gw
         - --win-minion-count=2
         - --enable-win-dsr=True
+        - --enable-ipv6dualstack=True
         - --container-runtime=docker
         - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.04.10
         - --cluster-name=capzflannel-l2br-$(BUILD_ID)
@@ -164,6 +165,7 @@ periodics:
         - --flannel-mode=host-gw
         - --win-minion-count=2
         - --enable-win-dsr=False
+        - --enable-ipv6dualstack=True
         - --container-runtime=docker
         - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.04.10
         - --cluster-name=capzdocker-ltsc2019-$(BUILD_ID)


### PR DESCRIPTION
The `IPv6DualStack` feature gate is working with Docker and
L2Bridge deployments.