### PR TITLE
Decrease timeouts

### DIFF
--- a/e2e-runner/e2e_runner/base.py
+++ b/e2e-runner/e2e_runner/base.py
@@ -116,7 +116,7 @@ class CI(object):
         cmd.append("--dump=%s" % self.opts.artifacts_directory)
         cmd.append(
             ('--test_args=--ginkgo.flakeAttempts=1 '
-             '--test.timeout=12h '
+             '--test.timeout=2h '
              '--num-nodes=2 --ginkgo.noColor '
              '--ginkgo.dryRun=%(dryRun)s '
              '--node-os-distro=windows '

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1,7 +1,7 @@
 plank:
   default_decoration_configs:
     "*":
-      timeout: 8h
+      timeout: 6h
       grace_period: 15m
       gcs_configuration:
         bucket: gs://k8s-ovn

--- a/prow/cronjobs/cleanup-azure-rgs.yaml
+++ b/prow/cronjobs/cleanup-azure-rgs.yaml
@@ -21,8 +21,8 @@ spec:
             command:
             - /workspace/cleanup-azure-rgs.py
             args:
-            # Cleanup resource groups older than 8h.
-            - --max-age-minutes=480
+            # Cleanup resource groups older than 6h.
+            - --max-age-minutes=360
             env:
             - name: AZURE_CLIENT_ID
               valueFrom:


### PR DESCRIPTION
* Use `6h` for Prowjobs' executions and Azure RGs age.
* Use `2h` for `kubetest` tests timeout.