### PR TITLE
Update CI Azure images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 __pycache__
 e2e_runner.egg-info
 
-/image-builder/azure-cbsl-init/*.offline
+image-builder/packer/azure-cbsl-init/packer-manifest.json

--- a/e2e-runner/Dockerfile
+++ b/e2e-runner/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:20.04
 
-ARG GO_VERSION=1.16
+ARG GO_VERSION=1.16.3
 ARG CAPI_VERSION=v0.3.15
-ARG KUBECTL_VERSION=v1.20.5
+ARG KUBECTL_VERSION=v1.21.0
 
 # Install system APT packages & dependencies
 RUN apt-get update && \

--- a/e2e-runner/e2e_runner/constants.py
+++ b/e2e-runner/e2e_runner/constants.py
@@ -1,6 +1,6 @@
 AZURE_LOCATIONS = ["eastus2", "westeurope", "westus2", "southcentralus"]
 
-DEFAULT_KUBERNETES_VERSION = "v1.20.5"
+DEFAULT_KUBERNETES_VERSION = "v1.21.0"
 
 SHARED_IMAGE_GALLERY_TYPE = "shared-image-gallery"
 MANAGED_IMAGE_TYPE = "managed-image"

--- a/e2e-runner/e2e_runner/deployer/capz/control-plane.yaml.j2
+++ b/e2e-runner/e2e_runner/deployer/capz/control-plane.yaml.j2
@@ -118,6 +118,6 @@ spec:
         marketplace:
           publisher: cncf-upstream
           offer: capi
-          sku: k8s-1dot20dot2-ubuntu-1804
-          version: "2021.01.13"
+          sku: k8s-1dot21dot0-ubuntu-1804
+          version: "2021.04.08"
 {%- endif %}

--- a/e2e-runner/e2e_runner/scripts/init-bootstrap-vm.sh
+++ b/e2e-runner/e2e_runner/scripts/init-bootstrap-vm.sh
@@ -3,7 +3,7 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-GO_VERSION="1.16"
+GO_VERSION="1.16.3"
 KIND_BIN_URL="https://github.com/kubernetes-sigs/kind/releases/download/v0.10.0/kind-linux-amd64"
 
 function retrycmd_if_failure() {

--- a/e2e-runner/e2e_runner/scripts/update-k8s.sh
+++ b/e2e-runner/e2e_runner/scripts/update-k8s.sh
@@ -57,7 +57,7 @@ for CI_IMAGE in "${CI_IMAGES[@]}"; do
     # remove unused image tag
     ctr -n k8s.io image remove "k8s.gcr.io/${CI_IMAGE}-amd64:${CI_VERSION//+/_}"
     # cleanup cached node image
-    crictl rmi "k8s.gcr.io/${CI_IMAGE}:v1.20.2"
+    crictl rmi "k8s.gcr.io/${CI_IMAGE}:v1.21.0"
 done
 
 echo "* checking binary versions"

--- a/image-builder/packer/azure-cbsl-init/README.md
+++ b/image-builder/packer/azure-cbsl-init/README.md
@@ -35,7 +35,7 @@ The current scripts support the following K8s Windows workers configurations:
     export ACR_USER_NAME="<ACR_USER_NAME>"
     export ACR_USER_PASSWORD="<ACR_USER_PASSWORD>"
 
-    export KUBERNETES_VERSION="v1.20.2"
+    export KUBERNETES_VERSION="v1.21.0"
     export FLANNEL_VERSION="v0.13.0"
     ```
 

--- a/image-builder/packer/azure-cbsl-init/k8s-node-setup/common.ps1
+++ b/image-builder/packer/azure-cbsl-init/k8s-node-setup/common.ps1
@@ -7,6 +7,10 @@ $OPT_DIR = Join-Path $env:SystemDrive "opt"
 
 $CNI_PLUGINS_VERSION = "0.9.1"
 $WINDOWS_CNI_PLUGINS_VERSION = "0.2.0"
+$WINS_VERSION = "0.1.0"
+$FLANNEL_VERSION = "0.13.0"
+
+$NSSM_URL = "https://k8stestinfrabinaries.blob.core.windows.net/nssm-mirror/nssm-2.24.zip"
 
 
 function Start-ExecuteWithRetry {
@@ -118,7 +122,7 @@ function Install-NSSM {
     Write-Output "Installing NSSM"
     mkdir -Force $NSSM_DIR
 
-    Start-FileDownload "https://k8stestinfrabinaries.blob.core.windows.net/nssm-mirror/nssm-2.24.zip" "$env:TEMP\nssm.zip"
+    Start-FileDownload $NSSM_URL "$env:TEMP\nssm.zip"
     tar -C "$NSSM_DIR" -xvf $env:TEMP\nssm.zip --strip-components 2 */win64/*.exe
     if($LASTEXITCODE) {
         Throw "Failed to unzip nssm.zip"
@@ -143,7 +147,7 @@ function Install-Kubelet {
 
     Start-FileDownload "https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubelet.exe" "$KUBERNETES_DIR\kubelet.exe"
     Start-FileDownload "https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubeadm.exe" "$KUBERNETES_DIR\kubeadm.exe"
-    Start-FileDownload "https://github.com/rancher/wins/releases/download/v0.1.0/wins.exe" "$KUBERNETES_DIR\wins.exe"
+    Start-FileDownload "https://github.com/rancher/wins/releases/download/v${WINS_VERSION}/wins.exe" "$KUBERNETES_DIR\wins.exe"
 
     Write-Output "Registering wins Windows service"
     wins.exe srv app run --register

--- a/image-builder/packer/azure-cbsl-init/k8s-node-setup/containerd/PrepareNode.ps1
+++ b/image-builder/packer/azure-cbsl-init/k8s-node-setup/containerd/PrepareNode.ps1
@@ -1,5 +1,5 @@
 Param(
-    [string]$KubernetesVersion="v1.20.5",
+    [string]$KubernetesVersion="v1.21.0",
     [Parameter(Mandatory=$true)]
     [string]$AcrName,
     [Parameter(Mandatory=$true)]
@@ -14,8 +14,8 @@ $ErrorActionPreference = "Stop"
 
 $CONTAINERD_DIR = Join-Path $env:SystemDrive "containerd"
 
-$CRI_CONTAINERD_VERSION = "1.4.3"
-$CRICTL_VERSION = "1.20.0"
+$CRI_CONTAINERD_VERSION = "1.4.4"
+$CRICTL_VERSION = "1.21.0"
 
 
 function Install-Containerd {
@@ -75,7 +75,7 @@ function Start-ContainerImagesPull {
         (Get-KubernetesPauseImage),
         (Get-NanoServerImage),
         "mcr.microsoft.com/windows/servercore:${windowsRelease}",
-        "${AcrName}.azurecr.io/flannel-windows:v0.13.0-windowsservercore-${windowsRelease}",
+        "${AcrName}.azurecr.io/flannel-windows:v${FLANNEL_VERSION}-windowsservercore-${windowsRelease}",
         "${AcrName}.azurecr.io/kube-proxy-windows:${KubernetesVersion}-windowsservercore-${windowsRelease}"
     )
     foreach($img in $images) {

--- a/image-builder/packer/azure-cbsl-init/k8s-node-setup/docker/PrepareNode.ps1
+++ b/image-builder/packer/azure-cbsl-init/k8s-node-setup/docker/PrepareNode.ps1
@@ -1,5 +1,5 @@
 Param(
-    [string]$KubernetesVersion="v1.20.5",
+    [string]$KubernetesVersion="v1.21.0",
     [Parameter(Mandatory=$true)]
     [string]$AcrName,
     [Parameter(Mandatory=$true)]
@@ -26,7 +26,7 @@ function Start-ContainerImagesPull {
         (Get-KubernetesPauseImage),
         (Get-NanoServerImage),
         "mcr.microsoft.com/windows/servercore:${windowsRelease}",
-        "${AcrName}.azurecr.io/flannel-windows:v0.13.0-windowsservercore-${windowsRelease}",
+        "${AcrName}.azurecr.io/flannel-windows:v${FLANNEL_VERSION}-windowsservercore-${windowsRelease}",
         "${AcrName}.azurecr.io/kube-proxy-windows:${KubernetesVersion}-windowsservercore-${windowsRelease}"
     )
     docker login "${AcrName}.azurecr.io" -u "${AcrName}" -p "${AcrUserPassword}"

--- a/image-builder/packer/azure-cbsl-init/windows.json
+++ b/image-builder/packer/azure-cbsl-init/windows.json
@@ -51,6 +51,7 @@
       "elevated_user": "packer",
       "elevated_password": "{{.WinRMPassword}}",
       "type": "powershell",
+      "elevated_execute_command": "powershell.exe -ExecutionPolicy Bypass -File {{.Path}}",
       "inline": ["New-Item -ItemType Directory -Force -Path C:\\k8s-node-setup"]
     },
     {
@@ -62,6 +63,7 @@
       "elevated_user": "packer",
       "elevated_password": "{{.WinRMPassword}}",
       "type": "powershell",
+      "elevated_execute_command": "powershell.exe -ExecutionPolicy Bypass -File {{.Path}}",
       "inline": ["C:\\k8s-node-setup\\setup-prerequisites.ps1 -ContainerRuntime {{ user `container_runtime` }}"]
     },
     {
@@ -71,6 +73,7 @@
       "elevated_user": "packer",
       "elevated_password": "{{.WinRMPassword}}",
       "type": "powershell",
+      "elevated_execute_command": "powershell.exe -ExecutionPolicy Bypass -File {{.Path}}",
       "inline": ["C:\\k8s-node-setup\\install-windows-features.ps1"]
     },
     {
@@ -80,6 +83,7 @@
       "elevated_user": "packer",
       "elevated_password": "{{.WinRMPassword}}",
       "type": "powershell",
+      "elevated_execute_command": "powershell.exe -ExecutionPolicy Bypass -File {{.Path}}",
       "inline": ["C:\\k8s-node-setup\\install-windows-updates.ps1"]
     },
     {
@@ -89,6 +93,7 @@
       "elevated_user": "packer",
       "elevated_password": "{{.WinRMPassword}}",
       "type": "powershell",
+      "elevated_execute_command": "powershell.exe -ExecutionPolicy Bypass -File {{.Path}}",
       "inline": [
         "C:\\k8s-node-setup\\{{ user `container_runtime` }}\\PrepareNode.ps1 -KubernetesVersion {{ user `kubernetes_version` }} -AcrName {{ user `acr_name` }} -AcrUserName {{ user `acr_user_name` }} -AcrUserPassword {{ user `acr_user_password` }}"
       ]
@@ -97,19 +102,28 @@
       "elevated_user": "packer",
       "elevated_password": "{{.WinRMPassword}}",
       "type": "powershell",
+      "elevated_execute_command": "powershell.exe -ExecutionPolicy Bypass -File {{.Path}}",
       "inline": ["C:\\k8s-node-setup\\cbsl-init\\install.ps1"]
     },
     {
       "elevated_user": "packer",
       "elevated_password": "{{.WinRMPassword}}",
       "type": "powershell",
+      "elevated_execute_command": "powershell.exe -ExecutionPolicy Bypass -File {{.Path}}",
       "inline": ["Remove-Item -Recurse -Force -Path C:\\k8s-node-setup"]
     },
     {
       "elevated_user": "packer",
       "elevated_password": "{{.WinRMPassword}}",
       "type": "powershell",
+      "elevated_execute_command": "powershell.exe -ExecutionPolicy Bypass -File {{.Path}}",
       "script": "k8s-node-setup/run-sysprep.ps1"
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "manifest",
+      "output": "packer-manifest.json"
     }
   ]
 }

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -30,7 +30,7 @@ periodics:
         - --enable-win-dsr=True
         - --enable-ipv6dualstack=True
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.04.10
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.04.13
         - --cluster-name=capzflannel-l2br-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-docker-flannel-winoverlay-master
@@ -63,7 +63,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.04.10
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.04.13
         - --cluster-name=capzflannel-ovrl-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-master
@@ -98,7 +98,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.04.10
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.04.13
         - --cluster-name=capzctrd-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnoverlay-master
@@ -133,7 +133,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.04.10
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.04.13
         - --cluster-name=capzctrd-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-docker-flannel-winbridge-dsr-disabled-master
@@ -167,7 +167,7 @@ periodics:
         - --enable-win-dsr=False
         - --enable-ipv6dualstack=True
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.04.10
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.04.13
         - --cluster-name=capzdocker-ltsc2019-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-docker-flannel-winoverlay-dsr-disabled-master
@@ -200,7 +200,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=False
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.04.10
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.04.13
         - --cluster-name=capzdocker-ltsc2019-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-stable
@@ -210,6 +210,7 @@ periodics:
   labels:
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
+    preset-windows-private-registry-cred: "true"
   spec:
     containers:
     - image: e2eteam/k8s-e2e-runner:latest
@@ -221,8 +222,8 @@ periodics:
         - --test=True
         - --down=True
         - --parallel-test-nodes=4
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-stable.yaml
+        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.21.x
+        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.21.x.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
         - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows
         - --build=sdncnibins
@@ -231,7 +232,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.04.10
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.04.13
         - --cluster-name=capzctrd-ltsc2019-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnoverlay-stable
@@ -241,6 +242,7 @@ periodics:
   labels:
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
+    preset-windows-private-registry-cred: "true"
   spec:
     containers:
     - image: e2eteam/k8s-e2e-runner:latest
@@ -252,8 +254,8 @@ periodics:
         - --test=True
         - --down=True
         - --parallel-test-nodes=4
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-stable.yaml
+        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.21.x
+        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.21.x.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
         - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows|Container.Lifecycle.Hook.when.create.a.pod.with.lifecycle.hook.should.execute.*.http.hook
         - --build=sdncnibins
@@ -262,7 +264,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.04.10
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.04.13
         - --cluster-name=capzctrd-ltsc2019-$(BUILD_ID)
 
 - name: k8s-e2e-sac1909-containerd-flannel-sdnbridge-stable
@@ -272,6 +274,7 @@ periodics:
   labels:
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
+    preset-windows-private-registry-cred: "true"
   spec:
     containers:
     - image: e2eteam/k8s-e2e-runner:latest
@@ -283,8 +286,8 @@ periodics:
         - --up=True
         - --down=True
         - --parallel-test-nodes=4
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-stable.yaml
+        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.21.x
+        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.21.x.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
         - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows
         - --build=sdncnibins
@@ -294,7 +297,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=1909
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-1909-containerd-cbsl-init:2021.04.10
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-1909-containerd-cbsl-init:2021.04.13
         - --cluster-name=capzctrd1909-$(BUILD_ID)
 
 - name: k8s-e2e-sac1909-containerd-flannel-sdnoverlay-stable
@@ -304,6 +307,7 @@ periodics:
   labels:
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
+    preset-windows-private-registry-cred: "true"
   spec:
     containers:
     - image: e2eteam/k8s-e2e-runner:latest
@@ -315,8 +319,8 @@ periodics:
         - --up=True
         - --down=True
         - --parallel-test-nodes=4
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-stable.yaml
+        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.21.x
+        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.21.x.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
         - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows|Container.Lifecycle.Hook.when.create.a.pod.with.lifecycle.hook.should.execute.*.http.hook
         - --build=sdncnibins
@@ -326,7 +330,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=1909
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-1909-containerd-cbsl-init:2021.04.10
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-1909-containerd-cbsl-init:2021.04.13
         - --cluster-name=capzctrd1909-$(BUILD_ID)
 
 - name: k8s-e2e-sac2004-containerd-flannel-sdnbridge-stable
@@ -348,8 +352,8 @@ periodics:
         - --up=True
         - --down=True
         - --parallel-test-nodes=4
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-2004
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-stable.yaml
+        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.21.x
+        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.21.x.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
         - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows
         - --build=sdncnibins
@@ -359,7 +363,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=2004
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.04.10
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.04.13
         - --cluster-name=capzctrd2004-$(BUILD_ID)
 
 - name: k8s-e2e-sac2004-containerd-flannel-sdnoverlay-stable
@@ -381,8 +385,8 @@ periodics:
         - --up=True
         - --down=True
         - --parallel-test-nodes=4
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-2004
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-stable.yaml
+        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.21.x
+        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.21.x.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
         - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows|Container.Lifecycle.Hook.when.create.a.pod.with.lifecycle.hook.should.execute.*.http.hook
         - --build=sdncnibins
@@ -392,5 +396,5 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=2004
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.04.10
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.04.13
         - --cluster-name=capzctrd2004-$(BUILD_ID)


### PR DESCRIPTION
* Bump stable Kubernetes version to `v1.21.0`.
* Bump Golang version to `1.16.3`.
* Bump CI Azure images version to `2021.04.13`.
* Small cleanup for the Packer Windows PowerShell scripts.
* Use explicit `elevated_execute_command` for the Packer PowerShell
  provisioner steps.
* Use Packer `manifest` post-processor.