### PR TITLE
Update Azure images

### DIFF
--- a/image-builder/packer/azure-cbsl-init/PSModules/KubernetesNodeSetup/Common.psm1
+++ b/image-builder/packer/azure-cbsl-init/PSModules/KubernetesNodeSetup/Common.psm1
@@ -6,11 +6,11 @@ $global:ETC_DIR = Join-Path $env:SystemDrive "etc"
 $global:NSSM_DIR = Join-Path $env:ProgramFiles "nssm"
 $global:OPT_DIR = Join-Path $env:SystemDrive "opt"
 
-$global:CNI_PLUGINS_VERSION = "0.9.1"
+$global:CNI_PLUGINS_VERSION = "1.0.0"
 $global:WINS_VERSION = "0.1.1"
 $global:FLANNEL_VERSION = "0.14.0"
-$global:CRI_CONTAINERD_VERSION = "1.5.3"
-$global:CRICTL_VERSION = "1.21.0"
+$global:CRI_CONTAINERD_VERSION = "1.5.5"
+$global:CRICTL_VERSION = "1.22.0"
 
 $global:NSSM_URL = "https://k8stestinfrabinaries.blob.core.windows.net/nssm-mirror/nssm-2.24.zip"
 
@@ -108,9 +108,6 @@ function Get-WindowsRelease {
 
 function Get-NanoServerImage {
     $release = Get-WindowsRelease
-    if($release -eq "ltsc2022") {
-        return "mcr.microsoft.com/windows/nanoserver/insider:10.0.20348.1"
-    }
     if($release -eq "ltsc2019") {
         $release = "1809"
     }
@@ -119,9 +116,6 @@ function Get-NanoServerImage {
 
 function Get-ServerCoreImage {
     $release = Get-WindowsRelease
-    if($release -eq "ltsc2022") {
-        return "mcr.microsoft.com/windows/servercore/insider:10.0.20348.1"
-    }
     return "mcr.microsoft.com/windows/servercore:$release"
 }
 
@@ -210,6 +204,7 @@ function Install-ContainerNetworkingPlugins {
     if($LASTEXITCODE) {
         Throw "Failed to extract cni-plugins.tgz"
     }
+    Start-FileDownload "https://capzwin.blob.core.windows.net/bin/flannel.exe" "$OPT_DIR\cni\bin\flannel.exe"
     Remove-Item -Force $env:TEMP\cni-plugins.tgz
 }
 

--- a/image-builder/packer/azure-cbsl-init/PSModules/KubernetesNodeSetup/cloudbase-init/cloudbase-init.conf
+++ b/image-builder/packer/azure-cbsl-init/PSModules/KubernetesNodeSetup/cloudbase-init/cloudbase-init.conf
@@ -30,6 +30,9 @@ metadata_report_provisioning_completed=True
 ephemeral_disk_volume_label="Temporary Storage"
 netbios_host_name_compatibility=True
 
+retry_count=200
+retry_count_interval=5
+
 metadata_services=cloudbaseinit.metadata.services.azureservice.AzureService
 plugins=cloudbaseinit.plugins.windows.createuser.CreateUserPlugin,
         cloudbaseinit.plugins.common.setuserpassword.SetUserPasswordPlugin,

--- a/image-builder/packer/azure-cbsl-init/windows-ltsc2022-containerd-variables.json
+++ b/image-builder/packer/azure-cbsl-init/windows-ltsc2022-containerd-variables.json
@@ -1,7 +1,7 @@
 {
-  "image_offer": "microsoftserveroperatingsystems-previews",
+  "image_offer": "WindowsServer",
   "image_publisher": "MicrosoftWindowsServer",
-  "image_sku": "windows-server-2022-azure-edition-core-preview",
+  "image_sku": "2022-datacenter-core-smalldisk-g2",
   "location": "westeurope",
   "vm_size": "Standard_D2s_v3",
   "image_name": "ws-ltsc2022-containerd-cbsl-init",

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -30,7 +30,7 @@ periodics:
         - --enable-win-dsr=True
         - --enable-ipv6dualstack=True
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.08.12
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.08.19
         - --cluster-name=capzflannel-l2br-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-docker-flannel-winoverlay-master
@@ -63,7 +63,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.08.12
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.08.19
         - --cluster-name=capzflannel-ovrl-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-master
@@ -98,7 +98,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.08.12
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.08.19
         - --cluster-name=capzctrd-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnoverlay-master
@@ -133,7 +133,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.08.12
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.08.19
         - --cluster-name=capzctrd-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-docker-flannel-winbridge-dsr-disabled-master
@@ -167,7 +167,7 @@ periodics:
         - --enable-win-dsr=False
         - --enable-ipv6dualstack=True
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.08.12
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.08.19
         - --cluster-name=capzdocker-ltsc2019-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-docker-flannel-winoverlay-dsr-disabled-master
@@ -200,7 +200,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=False
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.08.12
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.08.19
         - --cluster-name=capzdocker-ltsc2019-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-stable
@@ -232,7 +232,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.08.12
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.08.19
         - --cluster-name=capzctrd-ltsc2019-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnoverlay-stable
@@ -264,7 +264,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.08.12
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.08.19
         - --cluster-name=capzctrd-ltsc2019-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2022-containerd-flannel-sdnbridge-stable
@@ -297,7 +297,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=ltsc2022
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2022-containerd-cbsl-init:2021.08.12
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2022-containerd-cbsl-init:2021.08.19
         - --cluster-name=capzctrd-ltsc2022-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2022-containerd-flannel-sdnoverlay-stable
@@ -330,7 +330,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=ltsc2022
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2022-containerd-cbsl-init:2021.08.12
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2022-containerd-cbsl-init:2021.08.19
         - --cluster-name=capzctrd-ltsc2022-$(BUILD_ID)
 
 - name: k8s-e2e-sac1909-containerd-flannel-sdnbridge-stable
@@ -363,7 +363,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=1909
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-1909-containerd-cbsl-init:2021.08.12
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-1909-containerd-cbsl-init:2021.08.19
         - --cluster-name=capzctrd1909-$(BUILD_ID)
 
 - name: k8s-e2e-sac1909-containerd-flannel-sdnoverlay-stable
@@ -396,7 +396,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=1909
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-1909-containerd-cbsl-init:2021.08.12
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-1909-containerd-cbsl-init:2021.08.19
         - --cluster-name=capzctrd1909-$(BUILD_ID)
 
 - name: k8s-e2e-sac2004-containerd-flannel-sdnbridge-stable
@@ -429,7 +429,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=2004
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.08.12
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.08.19
         - --cluster-name=capzctrd2004-$(BUILD_ID)
 
 - name: k8s-e2e-sac2004-containerd-flannel-sdnoverlay-stable
@@ -462,5 +462,5 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=2004
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.08.12
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.08.19
         - --cluster-name=capzctrd2004-$(BUILD_ID)


### PR DESCRIPTION
* Update Azure images Packer scripts
  * Bump Azure images dependencies
    * `CNI_PLUGINS_VERSION` to `1.0.0`
    * `CRI_CONTAINERD_VERSION` to `1.5.5`
    * `CRICTL_VERSION` to `1.22.0`
* Use `2022-datacenter-core-smalldisk-g2` image for LTSC2022. This is the released Windows Server 2022 Azure image
* Bump Azure images to `2021.08.19` version
