### PR TITLE
Update Azure images & container images

### DIFF
--- a/e2e-runner/Dockerfile
+++ b/e2e-runner/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 
 ARG GO_VERSION=1.17
 ARG CAPI_VERSION=v0.4.0
-ARG KUBECTL_VERSION=v1.22.0
+ARG KUBECTL_VERSION=v1.22.1
 
 # Install system APT packages & dependencies
 RUN apt-get update && \

--- a/e2e-runner/Dockerfile
+++ b/e2e-runner/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 ARG GO_VERSION=1.17
-ARG CAPI_VERSION=v0.4.0
+ARG CAPI_VERSION=v0.4.2
 ARG KUBECTL_VERSION=v1.22.1
 
 # Install system APT packages & dependencies

--- a/e2e-runner/e2e_runner/ci/capz_flannel/flannel/kube-flannel-windows.Dockerfile
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/flannel/kube-flannel-windows.Dockerfile
@@ -1,17 +1,26 @@
-ARG flannelVersion="v0.14.0"
-ARG baseImage="mcr.microsoft.com/windows/servercore:ltsc2019"
+ARG BASE_IMAGE="mcr.microsoft.com/windows/servercore:ltsc2019"
+ARG WINS_VERSION="v0.1.1"
+ARG YQ_VERSION="v4.11.2"
+ARG FLANNEL_VERSION="v0.14.0"
 
-FROM ${baseImage}
-SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+# Linux stage
+FROM --platform=linux/amd64 alpine:latest as prep
 
-ARG flannelVersion
+ARG WINS_VERSION
+ARG YQ_VERSION
+ARG FLANNEL_VERSION
 
-RUN mkdir -force C:\k\flannel; \
-    pushd C:\k\flannel; \
-    Write-Output ${env:flannelVersion}; \
-    curl.exe -LO https://github.com/coreos/flannel/releases/download/${env:flannelVersion}/flanneld.exe
+RUN mkdir -p /k/flannel
 
-RUN mkdir C:\utils; \
-    curl.exe -Lo C:\utils\wins.exe https://github.com/rancher/wins/releases/download/v0.1.1/wins.exe; \
-    curl.exe -Lo C:\utils\yq.exe https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_windows_amd64.exe; \
-    "[Environment]::SetEnvironmentVariable('PATH', $env:PATH + ';C:\utils', [EnvironmentVariableTarget]::Machine)"
+ADD https://github.com/rancher/wins/releases/download/${WINS_VERSION}/wins.exe /wins.exe
+ADD https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_windows_amd64.exe /yq.exe
+ADD https://github.com/coreos/flannel/releases/download/${FLANNEL_VERSION}/flanneld.exe /k/flannel/flanneld.exe
+
+# Windows stage
+FROM $BASE_IMAGE
+
+COPY --from=prep /k /k
+COPY --from=prep /wins.exe /Windows/System32/wins.exe
+COPY --from=prep /yq.exe /Windows/System32/yq.exe
+
+ENV PATH="C:\Windows\System32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0"

--- a/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/kube-proxy-windows.Dockerfile
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/kube-proxy-windows.Dockerfile
@@ -1,4 +1,4 @@
-ARG k8sVersion="v1.22.0"
+ARG k8sVersion="v1.22.1"
 ARG baseImage="mcr.microsoft.com/windows/servercore:ltsc2019"
 
 FROM ${baseImage}

--- a/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/kube-proxy-windows.Dockerfile
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/kube-proxy-windows.Dockerfile
@@ -1,17 +1,26 @@
-ARG k8sVersion="v1.22.1"
-ARG baseImage="mcr.microsoft.com/windows/servercore:ltsc2019"
+ARG BASE_IMAGE="mcr.microsoft.com/windows/servercore:ltsc2019"
+ARG WINS_VERSION="v0.1.1"
+ARG YQ_VERSION="v4.11.2"
+ARG K8S_VERSION="v1.22.1"
 
-FROM ${baseImage}
-SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+# Linux stage
+FROM --platform=linux/amd64 alpine:latest as prep
 
-ARG k8sVersion
+ARG WINS_VERSION
+ARG YQ_VERSION
+ARG K8S_VERSION
 
-RUN mkdir -force C:\k\kube-proxy; \
-    pushd C:\k\kube-proxy; \
-    Write-Output ${env:k8sVersion}; \
-    curl.exe --fail -sLO https://dl.k8s.io/${env:k8sVersion}/bin/windows/amd64/kube-proxy.exe
+RUN mkdir -p /k/kube-proxy
 
-RUN mkdir C:\utils; \
-    curl.exe --fail -sLo C:\utils\wins.exe https://github.com/rancher/wins/releases/download/v0.1.1/wins.exe; \
-    curl.exe --fail -sLo C:\utils\yq.exe https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_windows_amd64.exe; \
-    "[Environment]::SetEnvironmentVariable('PATH', $env:PATH + ';C:\utils', [EnvironmentVariableTarget]::Machine)"
+ADD https://github.com/rancher/wins/releases/download/${WINS_VERSION}/wins.exe /wins.exe
+ADD https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_windows_amd64.exe /yq.exe
+ADD https://dl.k8s.io/${K8S_VERSION}/bin/windows/amd64/kube-proxy.exe /k/kube-proxy/kube-proxy.exe
+
+# Windows stage
+FROM $BASE_IMAGE
+
+COPY --from=prep /k /k
+COPY --from=prep /wins.exe /Windows/System32/wins.exe
+COPY --from=prep /yq.exe /Windows/System32/yq.exe
+
+ENV PATH="C:\Windows\System32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0"

--- a/e2e-runner/e2e_runner/constants.py
+++ b/e2e-runner/e2e_runner/constants.py
@@ -1,6 +1,6 @@
 AZURE_LOCATIONS = ["eastus2", "westeurope", "westus2", "southcentralus"]
 
-DEFAULT_KUBERNETES_VERSION = "v1.22.0"
+DEFAULT_KUBERNETES_VERSION = "v1.22.1"
 
 SHARED_IMAGE_GALLERY_TYPE = "shared-image-gallery"
 MANAGED_IMAGE_TYPE = "managed-image"

--- a/e2e-runner/e2e_runner/constants.py
+++ b/e2e-runner/e2e_runner/constants.py
@@ -16,4 +16,4 @@ CONTAINERD_SHIM_DIR = "./cmd/containerd-shim-runhcs-v1"
 CONTAINERD_SHIM_BIN = "containerd-shim-runhcs-v1.exe"
 
 CAPI_VERSION = "v0.4.2"
-CAPZ_PROVIDER_VERSION = "v0.5.1"
+CAPZ_PROVIDER_VERSION = "v0.5.2"

--- a/e2e-runner/e2e_runner/constants.py
+++ b/e2e-runner/e2e_runner/constants.py
@@ -15,5 +15,5 @@ KUBERNETES_IMAGES_LOCATION = "_output/release-images/amd64"
 CONTAINERD_SHIM_DIR = "./cmd/containerd-shim-runhcs-v1"
 CONTAINERD_SHIM_BIN = "containerd-shim-runhcs-v1.exe"
 
-CAPI_VERSION = "v0.4.0"
+CAPI_VERSION = "v0.4.2"
 CAPZ_PROVIDER_VERSION = "v0.5.1"

--- a/e2e-runner/e2e_runner/deployer/capz/capz.py
+++ b/e2e-runner/e2e_runner/deployer/capz/capz.py
@@ -1015,7 +1015,8 @@ class CAPZProvisioner(base.Deployer):
             "--core", ("cluster-api:%s" % constants.CAPI_VERSION),
             "--bootstrap", ("kubeadm:%s" % constants.CAPI_VERSION),
             "--control-plane", ("kubeadm:%s" % constants.CAPI_VERSION),
-            "--infrastructure", ("azure:%s" % constants.CAPZ_PROVIDER_VERSION)
+            "--infrastructure", ("azure:%s" % constants.CAPZ_PROVIDER_VERSION),
+            "--wait-providers"
         ])
         self.logging.info("Wait for the deployments to be available")
         utils.run_shell_cmd([

--- a/e2e-runner/e2e_runner/deployer/capz/control-plane.yaml.j2
+++ b/e2e-runner/e2e_runner/deployer/capz/control-plane.yaml.j2
@@ -125,16 +125,10 @@ spec:
       enableIPForwarding: true
 {%- endif %}
 {%- if k8s_bins %}
-      #image:
-      #  marketplace:
-      #    publisher: cncf-upstream
-      #    offer: capi
-      #    sku: k8s-1dot22dot0-ubuntu-2004
-      #    version: "2021.08.05"
-{%- endif %}
       image:
         marketplace:
           publisher: cncf-upstream
           offer: capi
           sku: k8s-1dot22dot0-ubuntu-2004
           version: latest
+{%- endif %}

--- a/e2e-runner/e2e_runner/deployer/capz/control-plane.yaml.j2
+++ b/e2e-runner/e2e_runner/deployer/capz/control-plane.yaml.j2
@@ -129,6 +129,6 @@ spec:
         marketplace:
           publisher: cncf-upstream
           offer: capi
-          sku: k8s-1dot22dot0-ubuntu-2004
+          sku: k8s-1dot22dot1-ubuntu-2004
           version: latest
 {%- endif %}

--- a/e2e-runner/e2e_runner/scripts/kubeadm-bootstrap.sh
+++ b/e2e-runner/e2e_runner/scripts/kubeadm-bootstrap.sh
@@ -60,7 +60,7 @@ update_k8s() {
         # remove unused image tag
         ctr -n k8s.io image remove "k8s.gcr.io/${CI_IMAGE}-amd64:${CI_VERSION//+/_}"
         # cleanup cached node image
-        crictl rmi "k8s.gcr.io/${CI_IMAGE}:v1.22.0"
+        crictl rmi "k8s.gcr.io/${CI_IMAGE}:v1.22.1"
     done
 
     echo "Checking binary versions"

--- a/image-builder/packer/azure-cbsl-init/PSModules/KubernetesNodeSetup/Common.psm1
+++ b/image-builder/packer/azure-cbsl-init/PSModules/KubernetesNodeSetup/Common.psm1
@@ -119,11 +119,7 @@ function Get-ServerCoreImage {
 }
 
 function Get-KubernetesPauseImage {
-    $release = Get-WindowsRelease
-    if($release -eq "ltsc2022") {
-        return "k8swin.azurecr.io/pause:3.6"
-    }
-    return "mcr.microsoft.com/oss/kubernetes/pause:1.4.1"
+    return "mcr.microsoft.com/oss/kubernetes/pause:3.6"
 }
 
 function Install-NSSM {

--- a/image-builder/packer/azure-cbsl-init/PSModules/KubernetesNodeSetup/KubernetesNodeSetup.psm1
+++ b/image-builder/packer/azure-cbsl-init/PSModules/KubernetesNodeSetup/KubernetesNodeSetup.psm1
@@ -180,7 +180,7 @@ function Set-DockerConfig {
 
 function Install-ContainerdKubernetesNode {
     Param(
-        [String]$KubernetesVersion="v1.22.0"
+        [String]$KubernetesVersion="v1.22.1"
     )
 
     Confirm-EnvVarsAreSet -EnvVars @("ACR_NAME", "ACR_USER_NAME", "ACR_USER_PASSWORD")
@@ -214,7 +214,7 @@ function Install-ContainerdKubernetesNode {
 
 function Install-DockerKubernetesNode {
     Param(
-        [String]$KubernetesVersion="v1.22.0"
+        [String]$KubernetesVersion="v1.22.1"
     )
 
     Confirm-EnvVarsAreSet -EnvVars @("ACR_NAME", "ACR_USER_NAME", "ACR_USER_PASSWORD")

--- a/image-builder/packer/azure-cbsl-init/README.md
+++ b/image-builder/packer/azure-cbsl-init/README.md
@@ -35,7 +35,7 @@ The current scripts support the following K8s Windows workers configurations:
     export ACR_USER_NAME="<ACR_USER_NAME>"
     export ACR_USER_PASSWORD="<ACR_USER_PASSWORD>"
 
-    export KUBERNETES_VERSION="v1.22.0"
+    export KUBERNETES_VERSION="v1.22.1"
     export FLANNEL_VERSION="v0.14.0"
     ```
 

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -322,7 +322,7 @@ periodics:
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.22.x-claudiubelu
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.22.x-claudiubelu.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
-        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows|Container.Lifecycle.Hook.when.create.a.pod.with.lifecycle.hook.should.execute.*.http.hook
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows|Container.Lifecycle.Hook.when.create.a.pod.with.lifecycle.hook.should.execute.*.http.hook|should.be.able.to.create.a.functioning.NodePort.service|should.be.able.to.change.the.type.from.ExternalName.to.NodePort
         - --build=sdncnibins
         - capz_flannel
         - --flannel-mode=overlay

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -30,7 +30,7 @@ periodics:
         - --enable-win-dsr=True
         - --enable-ipv6dualstack=True
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.08.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.09.01
         - --cluster-name=capzflannel-l2br-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-docker-flannel-winoverlay-master
@@ -63,7 +63,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.08.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.09.01
         - --cluster-name=capzflannel-ovrl-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-master
@@ -98,7 +98,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.08.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.09.01
         - --cluster-name=capzctrd-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnoverlay-master
@@ -133,7 +133,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.08.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.09.01
         - --cluster-name=capzctrd-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-docker-flannel-winbridge-dsr-disabled-master
@@ -167,7 +167,7 @@ periodics:
         - --enable-win-dsr=False
         - --enable-ipv6dualstack=True
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.08.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.09.01
         - --cluster-name=capzdocker-ltsc2019-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-docker-flannel-winoverlay-dsr-disabled-master
@@ -200,7 +200,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=False
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.08.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.09.01
         - --cluster-name=capzdocker-ltsc2019-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-stable
@@ -232,7 +232,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.08.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.09.01
         - --cluster-name=capzctrd-ltsc2019-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnoverlay-stable
@@ -264,7 +264,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.08.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.09.01
         - --cluster-name=capzctrd-ltsc2019-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2022-containerd-flannel-sdnbridge-stable
@@ -297,7 +297,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=ltsc2022
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2022-containerd-cbsl-init:2021.08.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2022-containerd-cbsl-init:2021.09.01
         - --cluster-name=capzctrd-ltsc2022-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2022-containerd-flannel-sdnoverlay-stable
@@ -330,7 +330,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=ltsc2022
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2022-containerd-cbsl-init:2021.08.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2022-containerd-cbsl-init:2021.09.01
         - --cluster-name=capzctrd-ltsc2022-$(BUILD_ID)
 
 - name: k8s-e2e-sac2004-containerd-flannel-sdnbridge-stable
@@ -363,7 +363,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=2004
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.08.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.09.01
         - --cluster-name=capzctrd2004-$(BUILD_ID)
 
 - name: k8s-e2e-sac2004-containerd-flannel-sdnoverlay-stable
@@ -396,5 +396,5 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=2004
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.08.19
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.09.01
         - --cluster-name=capzctrd2004-$(BUILD_ID)

--- a/tools/kube-backup/Dockerfile
+++ b/tools/kube-backup/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:20.04
 
 ENV K8S_VERSION=1.22.1
 ENV DEBIAN_FRONTEND=noninteractive

--- a/tools/kube-backup/Dockerfile
+++ b/tools/kube-backup/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:latest
 
-ENV K8S_VERSION=1.22.0
+ENV K8S_VERSION=1.22.1
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \


### PR DESCRIPTION
* Remove temporary workaround
  * This was temporarily introduced with the change https://github.com/e2e-win/k8s-e2e-runner/commit/bcc8743fc842cc47aeb5c93b8c7d243cef0f5d1f
* Bump default Kubernetes version to `v1.22.1`
* Change tools/kube-backup container base image
  * Use `ubuntu:20.04` instead of `ubuntu:latest`
* Bump cluster-api version to `v0.4.2`
  * Use the new functionality to wait for the cluster to be ready via the flag `--wait-providers`
* Bump cluster-api-provider-azure to `v0.5.2`
* Update Kubernetes pause image
  * Use `mcr.microsoft.com/oss/kubernetes/pause:3.6` container image
* Rewrite kube-proxy & flannel Dockerfiles
  * The new Dockerfiles are meant to be used with `docker buildx`
  * This will allow building Windows container images on a Linux machine
* Bump Azure images' versions
* Skip the following tests on LTSC 2022 with overlay CNI:
  * `[sig-windows] Services [It] should be able to create a functioning NodePort service for Windows`
  * `[sig-network] Services [It] should be able to create a functioning NodePort service [Conformance]`
  * `[sig-network] Services [It] should be able to change the type from ExternalName to NodePort [Conformance]`