### PR TITLE
Add setup_infra to CI base class

### DIFF
--- a/e2e-runner/e2e_runner/base.py
+++ b/e2e-runner/e2e_runner/base.py
@@ -29,6 +29,9 @@ class CI(object):
         self.e2e_runner_dir = os.path.dirname(__file__)
         self.deployer = Deployer()
 
+    def setup_infra(self):
+        self.logging.info("Setup Infra: Default NOOP")
+
     def up(self):
         self.logging.info("UP: Default NOOP")
 

--- a/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
@@ -59,6 +59,9 @@ class CapzFlannelCI(base.CI):
             tags['jobName'] = job_name
         return tags
 
+    def setup_infra(self):
+        return self.deployer.setup_infra()
+
     def build(self, bins_to_build):
         builder_mapping = {
             "k8sbins": self._build_k8s_artifacts,


### PR DESCRIPTION
Instead of calling `_setup_infra()` in the capz `__init__`, use a dedicated method in the CI base class.