### PR TITLE
Improve Windows agents setup

### DIFF
--- a/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
@@ -81,7 +81,6 @@ class CapzFlannelCI(base.CI):
     def up(self):
         start = time.time()
         self.deployer.up()
-        self.deployer.wait_for_agents(timeout=7200)
         if self.opts.flannel_mode == constants.FLANNEL_MODE_L2BRIDGE:
             self.deployer.connect_agents_to_controlplane_subnet()
             self.deployer.enable_ip_forwarding()

--- a/e2e-runner/e2e_runner/deployer/capz/windows-agents.yaml.j2
+++ b/e2e-runner/e2e_runner/deployer/capz/windows-agents.yaml.j2
@@ -1,20 +1,5 @@
 ---
 apiVersion: cluster.x-k8s.io/v1alpha4
-kind: MachineHealthCheck
-metadata:
-  name: {{ cluster_name }}-nodes-unhealthy
-spec:
-  clusterName: {{ cluster_name }}
-  nodeStartupTimeout: 10m
-  selector:
-    matchLabels:
-      cluster.x-k8s.io/deployment-name: {{ cluster_name }}-md-win
-  unhealthyConditions:
-    - type: Ready
-      status: Unknown
-      timeout: 5m
----
-apiVersion: cluster.x-k8s.io/v1alpha4
 kind: MachineDeployment
 metadata:
   name: {{ cluster_name }}-md-win


### PR DESCRIPTION
Add retry logic to re-create the Windows agents in the `e2e_runner`.

Remove Windows agents' `MachineHealthCheck` since this will not be needed anymore.