### PR TITLE
Bump CI dependencies

### DIFF
--- a/e2e-runner/Dockerfile
+++ b/e2e-runner/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:20.04
 
-ARG GO_VERSION=1.17
-ARG CAPI_VERSION=v0.4.2
-ARG KUBECTL_VERSION=v1.22.1
+ARG GO_VERSION=1.17.1
+ARG CAPI_VERSION=v0.4.3
+ARG KUBECTL_VERSION=v1.22.2
 
 # Install system APT packages & dependencies
 RUN apt-get update && \

--- a/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/kube-proxy-windows.Dockerfile
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/kube-proxy-windows.Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE="mcr.microsoft.com/windows/servercore:ltsc2019"
 ARG WINS_VERSION="v0.1.1"
 ARG YQ_VERSION="v4.11.2"
-ARG K8S_VERSION="v1.22.1"
+ARG K8S_VERSION="v1.22.2"
 
 # Linux stage
 FROM --platform=linux/amd64 alpine:latest as prep

--- a/e2e-runner/e2e_runner/constants.py
+++ b/e2e-runner/e2e_runner/constants.py
@@ -1,6 +1,6 @@
 AZURE_LOCATIONS = ["eastus2", "westeurope", "westus2", "southcentralus"]
 
-DEFAULT_KUBERNETES_VERSION = "v1.22.1"
+DEFAULT_KUBERNETES_VERSION = "v1.22.2"
 
 SHARED_IMAGE_GALLERY_TYPE = "shared-image-gallery"
 MANAGED_IMAGE_TYPE = "managed-image"
@@ -15,5 +15,5 @@ KUBERNETES_IMAGES_LOCATION = "_output/release-images/amd64"
 CONTAINERD_SHIM_DIR = "./cmd/containerd-shim-runhcs-v1"
 CONTAINERD_SHIM_BIN = "containerd-shim-runhcs-v1.exe"
 
-CAPI_VERSION = "v0.4.2"
+CAPI_VERSION = "v0.4.3"
 CAPZ_PROVIDER_VERSION = "v0.5.2"

--- a/e2e-runner/e2e_runner/deployer/capz/capz.py
+++ b/e2e-runner/e2e_runner/deployer/capz/capz.py
@@ -1043,3 +1043,4 @@ class CAPZProvisioner(base.Deployer):
         # Set Azure location if it's not set already
         if not self.azure_location:
             self.azure_location = random.choice(constants.AZURE_LOCATIONS)
+        self.logging.info("Using Azure location %s", self.azure_location)

--- a/e2e-runner/e2e_runner/deployer/capz/control-plane.yaml.j2
+++ b/e2e-runner/e2e_runner/deployer/capz/control-plane.yaml.j2
@@ -129,6 +129,6 @@ spec:
         marketplace:
           publisher: cncf-upstream
           offer: capi
-          sku: k8s-1dot22dot1-ubuntu-2004
+          sku: k8s-1dot22dot2-ubuntu-2004
           version: latest
 {%- endif %}

--- a/e2e-runner/e2e_runner/scripts/init-bootstrap-vm.sh
+++ b/e2e-runner/e2e_runner/scripts/init-bootstrap-vm.sh
@@ -3,7 +3,7 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-GO_VERSION="1.17"
+GO_VERSION="1.17.1"
 KIND_BIN_URL="https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-linux-amd64"
 
 function retrycmd_if_failure() {

--- a/e2e-runner/e2e_runner/scripts/kubeadm-bootstrap.sh
+++ b/e2e-runner/e2e_runner/scripts/kubeadm-bootstrap.sh
@@ -60,7 +60,7 @@ update_k8s() {
         # remove unused image tag
         ctr -n k8s.io image remove "k8s.gcr.io/${CI_IMAGE}-amd64:${CI_VERSION//+/_}"
         # cleanup cached node image
-        crictl rmi "k8s.gcr.io/${CI_IMAGE}:v1.22.1"
+        crictl rmi "k8s.gcr.io/${CI_IMAGE}:v1.22.2"
     done
 
     echo "Checking binary versions"

--- a/image-builder/packer/azure-cbsl-init/PSModules/KubernetesNodeSetup/Common.psm1
+++ b/image-builder/packer/azure-cbsl-init/PSModules/KubernetesNodeSetup/Common.psm1
@@ -6,7 +6,7 @@ $global:ETC_DIR = Join-Path $env:SystemDrive "etc"
 $global:NSSM_DIR = Join-Path $env:ProgramFiles "nssm"
 $global:OPT_DIR = Join-Path $env:SystemDrive "opt"
 
-$global:CNI_PLUGINS_VERSION = "1.0.0"
+$global:CNI_PLUGINS_VERSION = "1.0.1"
 $global:WINS_VERSION = "0.1.1"
 $global:FLANNEL_VERSION = "0.14.0"
 $global:CRI_CONTAINERD_VERSION = "1.5.5"

--- a/image-builder/packer/azure-cbsl-init/PSModules/KubernetesNodeSetup/KubernetesNodeSetup.psm1
+++ b/image-builder/packer/azure-cbsl-init/PSModules/KubernetesNodeSetup/KubernetesNodeSetup.psm1
@@ -180,7 +180,7 @@ function Set-DockerConfig {
 
 function Install-ContainerdKubernetesNode {
     Param(
-        [String]$KubernetesVersion="v1.22.1"
+        [String]$KubernetesVersion="v1.22.2"
     )
 
     Confirm-EnvVarsAreSet -EnvVars @("ACR_NAME", "ACR_USER_NAME", "ACR_USER_PASSWORD")
@@ -214,7 +214,7 @@ function Install-ContainerdKubernetesNode {
 
 function Install-DockerKubernetesNode {
     Param(
-        [String]$KubernetesVersion="v1.22.1"
+        [String]$KubernetesVersion="v1.22.2"
     )
 
     Confirm-EnvVarsAreSet -EnvVars @("ACR_NAME", "ACR_USER_NAME", "ACR_USER_PASSWORD")

--- a/image-builder/packer/azure-cbsl-init/README.md
+++ b/image-builder/packer/azure-cbsl-init/README.md
@@ -35,7 +35,7 @@ The current scripts support the following K8s Windows workers configurations:
     export ACR_USER_NAME="<ACR_USER_NAME>"
     export ACR_USER_PASSWORD="<ACR_USER_PASSWORD>"
 
-    export KUBERNETES_VERSION="v1.22.1"
+    export KUBERNETES_VERSION="v1.22.2"
     export FLANNEL_VERSION="v0.14.0"
     ```
 

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -30,7 +30,7 @@ periodics:
         - --enable-win-dsr=True
         - --enable-ipv6dualstack=True
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.09.01
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.09.27
         - --cluster-name=capzflannel-l2br-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-docker-flannel-winoverlay-master
@@ -63,7 +63,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.09.01
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.09.27
         - --cluster-name=capzflannel-ovrl-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-master
@@ -98,7 +98,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.09.01
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.09.27
         - --cluster-name=capzctrd-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnoverlay-master
@@ -133,7 +133,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.09.01
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.09.27
         - --cluster-name=capzctrd-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-docker-flannel-winbridge-dsr-disabled-master
@@ -167,7 +167,7 @@ periodics:
         - --enable-win-dsr=False
         - --enable-ipv6dualstack=True
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.09.01
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.09.27
         - --cluster-name=capzdocker-ltsc2019-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-docker-flannel-winoverlay-dsr-disabled-master
@@ -200,7 +200,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=False
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.09.01
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.09.27
         - --cluster-name=capzdocker-ltsc2019-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-stable
@@ -232,7 +232,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.09.01
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.09.27
         - --cluster-name=capzctrd-ltsc2019-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnoverlay-stable
@@ -264,7 +264,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.09.01
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.09.27
         - --cluster-name=capzctrd-ltsc2019-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2022-containerd-flannel-sdnbridge-stable
@@ -297,7 +297,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=ltsc2022
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2022-containerd-cbsl-init:2021.09.01
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2022-containerd-cbsl-init:2021.09.27
         - --cluster-name=capzctrd-ltsc2022-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2022-containerd-flannel-sdnoverlay-stable
@@ -330,7 +330,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=ltsc2022
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2022-containerd-cbsl-init:2021.09.01
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2022-containerd-cbsl-init:2021.09.27
         - --cluster-name=capzctrd-ltsc2022-$(BUILD_ID)
 
 - name: k8s-e2e-sac2004-containerd-flannel-sdnbridge-stable
@@ -363,7 +363,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=2004
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.09.01
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.09.27
         - --cluster-name=capzctrd2004-$(BUILD_ID)
 
 - name: k8s-e2e-sac2004-containerd-flannel-sdnoverlay-stable
@@ -396,5 +396,5 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=2004
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.09.01
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.09.27
         - --cluster-name=capzctrd2004-$(BUILD_ID)

--- a/tools/kube-backup/Dockerfile
+++ b/tools/kube-backup/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ENV K8S_VERSION=1.22.1
+ENV K8S_VERSION=1.22.2
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \


### PR DESCRIPTION
* Log info message with Azure location used
* Bump dependencies' releases
  * Bump default `kubernetes` version
  * Bump `cluster-api` version
  * Bump `golang` version
  * Bump `containernetworking/plugins` version
* Bump Azure images to `2021.09.27`