### PR TITLE
CAPZ Deployer Updates

### DIFF
--- a/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
@@ -83,7 +83,6 @@ class CapzFlannelCI(base.CI):
         self.deployer.up()
         if self.opts.flannel_mode == constants.FLANNEL_MODE_L2BRIDGE:
             self.deployer.connect_agents_to_controlplane_subnet()
-            self.deployer.enable_ip_forwarding()
         self.deployer.setup_ssh_config()
         self._setup_kubeconfig()
         extra_kubelet_args = [

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -62,6 +62,7 @@ periodics:
         - --flannel-mode=overlay
         - --win-minion-count=2
         - --enable-win-dsr=True
+        - --enable-ipv6dualstack=True
         - --container-runtime=docker
         - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.09.27
         - --cluster-name=capzflannel-ovrl-$(BUILD_ID)
@@ -97,6 +98,7 @@ periodics:
         - --flannel-mode=host-gw
         - --win-minion-count=2
         - --enable-win-dsr=True
+        - --enable-ipv6dualstack=True
         - --container-runtime=containerd
         - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.09.27
         - --cluster-name=capzctrd-$(BUILD_ID)
@@ -132,6 +134,7 @@ periodics:
         - --flannel-mode=overlay
         - --win-minion-count=2
         - --enable-win-dsr=True
+        - --enable-ipv6dualstack=True
         - --container-runtime=containerd
         - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.09.27
         - --cluster-name=capzctrd-$(BUILD_ID)
@@ -199,6 +202,7 @@ periodics:
         - --flannel-mode=overlay
         - --win-minion-count=2
         - --enable-win-dsr=False
+        - --enable-ipv6dualstack=True
         - --container-runtime=docker
         - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.09.27
         - --cluster-name=capzdocker-ltsc2019-$(BUILD_ID)


### PR DESCRIPTION
* Use 128GB for the bootstrap VM OS disk size
* Use models instead of plain dicts for network, compute, and
  mgmt resources paramtereters
* Remove explicit enable of IP forwarding since this done by the
  `cluster-api-provider-azure`
* Enable IPv6 for `master` branch jobs. On latest Kubernetes code,
  this feature gate is locked to be enabled