### PR TITLE
Remove westus2 location

### DIFF
--- a/e2e-runner/e2e_runner/constants.py
+++ b/e2e-runner/e2e_runner/constants.py
@@ -1,4 +1,4 @@
-AZURE_LOCATIONS = ["eastus2", "westeurope", "westus2", "southcentralus"]
+AZURE_LOCATIONS = ["eastus2", "westeurope", "southcentralus"]
 
 DEFAULT_KUBERNETES_VERSION = "v1.22.2"
 


### PR DESCRIPTION
This location sometimes has troubles spawning the Windows agents.
Temporarily disable it until a resolution is found.