### PR TITLE
Fix L2Bridge deployments

### DIFF
--- a/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
@@ -85,11 +85,6 @@ class CapzFlannelCI(base.CI):
             self.deployer.connect_agents_to_controlplane_subnet()
         self.deployer.setup_ssh_config()
         self._setup_kubeconfig()
-        extra_kubelet_args = [
-            "--feature-gates='IPv6DualStack={}'".format(
-                str(self.opts.enable_ipv6dualstack).lower()),
-        ]
-        self.deployer.add_win_agents_kubelet_args(extra_kubelet_args)
         self._install_patches()
         if "k8sbins" in self.deployer.bins_built:
             self._upload_kube_proxy_windows_bin()
@@ -425,12 +420,10 @@ class CapzFlannelCI(base.CI):
             self.capz_flannel_dir, "kube-proxy/kube-proxy-windows.yaml.j2")
         server_core_tag = "windowsservercore-%s" % (
             self.opts.base_container_image_tag)
-        enable_ipv6dualstack = str(self.opts.enable_ipv6dualstack).lower()
         context = {
             "kubernetes_version": self.kubernetes_version,
             "server_core_tag": server_core_tag,
             "enable_win_dsr": str(self.opts.enable_win_dsr).lower(),
-            "enable_ipv6dualstack": enable_ipv6dualstack,
             "flannel_mode": self.opts.flannel_mode
         }
         output_file = "/tmp/kube-proxy-windows.yaml"

--- a/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/kube-proxy-windows.yaml.j2
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/kube-proxy-windows.yaml.j2
@@ -27,7 +27,6 @@ data:
     yq eval -i '.winkernel.enableDSR = true' /host/var/lib/kube-proxy/config.conf
     yq eval -i '.featureGates.WinDSR = true' /host/var/lib/kube-proxy/config.conf
 {%- endif %}
-    yq eval -i '.featureGates.IPv6DualStack = {{ enable_ipv6dualstack }}' /host/var/lib/kube-proxy/config.conf
     yq eval -i '.mode = ""kernelspace""' /host/var/lib/kube-proxy/config.conf
 
   run.ps1: |

--- a/e2e-runner/e2e_runner/cli/run_ci.py
+++ b/e2e-runner/e2e_runner/cli/run_ci.py
@@ -107,10 +107,6 @@ class RunCI(Command):
                        "overwriten by the version of the newly built k8s "
                        "binaries")
         p.add_argument('--enable-win-dsr', type=utils.str2bool, default=False)
-        p.add_argument('--enable-ipv6dualstack',
-                       type=utils.str2bool, default=False,
-                       help='Enables the IPv6DualStack feature gate for '
-                       'kubelet and kube-proxy.')
         p.add_argument("--cluster-name", required=True,
                        help="The cluster name given to the cluster-api "
                        "manifest. This value is used for the Azure resource "

--- a/e2e-runner/e2e_runner/deployer/capz/capz.py
+++ b/e2e-runner/e2e_runner/deployer/capz/capz.py
@@ -378,13 +378,9 @@ class CAPZProvisioner(base.Deployer):
 
             self.logging.info("Updating VM NIC subnet")
             nic.ip_configurations[0].subnet.id = control_plane_subnet.id
-            nic_parameters = net_models.NetworkInterface(
-                id=nic.id,
-                location=self.azure_location,
-                ip_configurations=nic.ip_configurations)
             utils.retry_on_error()(
                 self.network_client.network_interfaces.begin_create_or_update)(
-                    self.cluster_name, nic.name, nic_parameters).wait()
+                    self.cluster_name, nic.name, nic).wait()
 
             self.logging.info("Starting VM")
             utils.retry_on_error()(

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -28,7 +28,6 @@ periodics:
         - --flannel-mode=host-gw
         - --win-minion-count=2
         - --enable-win-dsr=True
-        - --enable-ipv6dualstack=True
         - --container-runtime=docker
         - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.09.27
         - --cluster-name=capzflannel-l2br-$(BUILD_ID)
@@ -62,7 +61,6 @@ periodics:
         - --flannel-mode=overlay
         - --win-minion-count=2
         - --enable-win-dsr=True
-        - --enable-ipv6dualstack=True
         - --container-runtime=docker
         - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.09.27
         - --cluster-name=capzflannel-ovrl-$(BUILD_ID)
@@ -98,7 +96,6 @@ periodics:
         - --flannel-mode=host-gw
         - --win-minion-count=2
         - --enable-win-dsr=True
-        - --enable-ipv6dualstack=True
         - --container-runtime=containerd
         - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.09.27
         - --cluster-name=capzctrd-$(BUILD_ID)
@@ -134,7 +131,6 @@ periodics:
         - --flannel-mode=overlay
         - --win-minion-count=2
         - --enable-win-dsr=True
-        - --enable-ipv6dualstack=True
         - --container-runtime=containerd
         - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.09.27
         - --cluster-name=capzctrd-$(BUILD_ID)
@@ -168,7 +164,6 @@ periodics:
         - --flannel-mode=host-gw
         - --win-minion-count=2
         - --enable-win-dsr=False
-        - --enable-ipv6dualstack=True
         - --container-runtime=docker
         - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.09.27
         - --cluster-name=capzdocker-ltsc2019-$(BUILD_ID)
@@ -202,7 +197,6 @@ periodics:
         - --flannel-mode=overlay
         - --win-minion-count=2
         - --enable-win-dsr=False
-        - --enable-ipv6dualstack=True
         - --container-runtime=docker
         - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.09.27
         - --cluster-name=capzdocker-ltsc2019-$(BUILD_ID)


### PR DESCRIPTION
* Remove `--enable-ipv6dualstack` parameter
* Fix l2bridge deployments

  Use the same nic object when updating the VM nic ip config.

  Otherwise, some NIC configs are lost (like `IPForwarding`), which is
  necessary for l2bridge deployments.