### PR TITLE
Update `--test-skip-regex`

### DIFF
--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -21,7 +21,7 @@ periodics:
         - --repo-list=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-master
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
-        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|\[Feature\:GPUDevicePlugin\]|\[Excluded\:WindowsDocker\]
         - --k8s-branch=master
         - --build=k8sbins
         - capz_flannel
@@ -54,7 +54,7 @@ periodics:
         - --repo-list=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-master
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
-        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|Container.Lifecycle.Hook.when.create.a.pod.with.lifecycle.hook.should.execute.*.http.hook
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|\[Feature\:GPUDevicePlugin\]|\[Excluded\:WindowsDocker\]
         - --k8s-branch=master
         - --build=k8sbins
         - capz_flannel
@@ -87,7 +87,7 @@ periodics:
         - --repo-list=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-master
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
-        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows|should.not.be.able.to.create.pods.with.unknown.usernames
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|\[Feature\:GPUDevicePlugin\]|should.not.be.able.to.create.pods.with.unknown.usernames
         - --k8s-branch=master
         - --build=k8sbins
         - --build=containerdbins
@@ -122,7 +122,7 @@ periodics:
         - --repo-list=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-master
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
-        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows|Container.Lifecycle.Hook.when.create.a.pod.with.lifecycle.hook.should.execute.*.http.hook|should.not.be.able.to.create.pods.with.unknown.usernames
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|\[Feature\:GPUDevicePlugin\]|should.not.be.able.to.create.pods.with.unknown.usernames
         - --k8s-branch=master
         - --build=k8sbins
         - --build=containerdbins
@@ -157,7 +157,7 @@ periodics:
         - --repo-list=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-master
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
-        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|\[Feature\:GPUDevicePlugin\]|\[Excluded\:WindowsDocker\]
         - --k8s-branch=master
         - --build=k8sbins
         - capz_flannel
@@ -190,7 +190,7 @@ periodics:
         - --repo-list=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-master
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
-        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|device.plugin.for.Windows|Container.Lifecycle.Hook.when.create.a.pod.with.lifecycle.hook.should.execute.*.http.hook
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application|\[Feature\:GPUDevicePlugin\]|\[Excluded\:WindowsDocker\]
         - --k8s-branch=master
         - --build=k8sbins
         - capz_flannel
@@ -223,7 +223,7 @@ periodics:
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.22.x
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.22.x.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
-        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|\[Feature\:GPUDevicePlugin\]
         - --build=sdncnibins
         - capz_flannel
         - --flannel-mode=host-gw
@@ -255,7 +255,7 @@ periodics:
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.22.x
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.22.x.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
-        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows|Container.Lifecycle.Hook.when.create.a.pod.with.lifecycle.hook.should.execute.*.http.hook
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|\[Feature\:GPUDevicePlugin\]|Container.Lifecycle.Hook.when.create.a.pod.with.lifecycle.hook.should.execute.*.http.hook
         - --build=sdncnibins
         - capz_flannel
         - --flannel-mode=overlay
@@ -287,7 +287,7 @@ periodics:
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.22.x-claudiubelu
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.22.x-claudiubelu.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
-        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|\[Feature\:GPUDevicePlugin\]
         - --build=sdncnibins
         - capz_flannel
         - --flannel-mode=host-gw
@@ -320,7 +320,7 @@ periodics:
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.22.x-claudiubelu
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.22.x-claudiubelu.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
-        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows|Container.Lifecycle.Hook.when.create.a.pod.with.lifecycle.hook.should.execute.*.http.hook|should.be.able.to.create.a.functioning.NodePort.service|should.be.able.to.change.the.type.from.ExternalName.to.NodePort
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|\[Feature\:GPUDevicePlugin\]|Container.Lifecycle.Hook.when.create.a.pod.with.lifecycle.hook.should.execute.*.http.hook|should.be.able.to.create.a.functioning.NodePort.service|should.be.able.to.change.the.type.from.ExternalName.to.NodePort
         - --build=sdncnibins
         - capz_flannel
         - --flannel-mode=overlay
@@ -353,7 +353,7 @@ periodics:
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.22.x
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.22.x.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
-        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|\[Feature\:GPUDevicePlugin\]
         - --build=sdncnibins
         - capz_flannel
         - --flannel-mode=host-gw
@@ -386,7 +386,7 @@ periodics:
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.22.x
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.22.x.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
-        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|device.plugin.for.Windows|Container.Lifecycle.Hook.when.create.a.pod.with.lifecycle.hook.should.execute.*.http.hook
+        - --test-skip-regex=\[LinuxOnly\]|\[Serial\]|\[Slow\]|\[alpha\]|GMSA|\[Feature\:GPUDevicePlugin\]|Container.Lifecycle.Hook.when.create.a.pod.with.lifecycle.hook.should.execute.*.http.hook
         - --build=sdncnibins
         - capz_flannel
         - --flannel-mode=overlay


### PR DESCRIPTION
* Skip the `[Excluded:WindowsDocker]` tests for the Docker jobs
* Use `[Feature:GPUDevicePlugin]` skip regex instead of `device.plugin.for.Windows`
* Don't skip `Container.Lifecycle.Hook.when.create.a.pod.with.lifecycle.hook.should.execute.*.http.hook`
  tests on containerd master jobs since these are fixed