### PR TITLE
Update LTSC2022 CI Azure images

### DIFF
--- a/image-builder/packer/azure-cbsl-init/0-setup.ps1
+++ b/image-builder/packer/azure-cbsl-init/0-setup.ps1
@@ -2,8 +2,10 @@ $ErrorActionPreference = "Stop"
 
 Import-Module KubernetesNodeSetup
 
-Confirm-EnvVarsAreSet -EnvVars @("CONTAINER_RUNTIME")
-Install-LatestWindowsUpdates
+Confirm-EnvVarsAreSet -EnvVars @("CONTAINER_RUNTIME", "INSTALL_LATEST_WINDOWS_UPDATES")
+if([System.Convert]::ToBoolean($env:INSTALL_LATEST_WINDOWS_UPDATES)) {
+    Install-LatestWindowsUpdates
+}
 Install-RequiredWindowsFeatures
 if($env:CONTAINER_RUNTIME -eq "docker") {
     Install-PackageProvider -Name NuGet -Force -Confirm:$false

--- a/image-builder/packer/azure-cbsl-init/windows-ltsc2019-containerd-variables.json
+++ b/image-builder/packer/azure-cbsl-init/windows-ltsc2019-containerd-variables.json
@@ -2,6 +2,8 @@
   "image_offer": "WindowsServer",
   "image_publisher": "MicrosoftWindowsServer",
   "image_sku": "2019-Datacenter-Core-with-Containers-smalldisk-g2",
+  "image_version": "latest",
+  "install_latest_windows_updates": "false",
   "location": "westeurope",
   "vm_size": "Standard_D2s_v3",
   "image_name": "ws-ltsc2019-containerd-cbsl-init",

--- a/image-builder/packer/azure-cbsl-init/windows-ltsc2019-docker-variables.json
+++ b/image-builder/packer/azure-cbsl-init/windows-ltsc2019-docker-variables.json
@@ -2,6 +2,8 @@
   "image_offer": "WindowsServer",
   "image_publisher": "MicrosoftWindowsServer",
   "image_sku": "2019-Datacenter-Core-with-Containers-smalldisk-g2",
+  "image_version": "latest",
+  "install_latest_windows_updates": "false",
   "location": "westeurope",
   "vm_size": "Standard_D2s_v3",
   "image_name": "ws-ltsc2019-docker-cbsl-init",

--- a/image-builder/packer/azure-cbsl-init/windows-ltsc2022-containerd-variables.json
+++ b/image-builder/packer/azure-cbsl-init/windows-ltsc2022-containerd-variables.json
@@ -2,7 +2,7 @@
   "image_offer": "WindowsServer",
   "image_publisher": "MicrosoftWindowsServer",
   "image_sku": "2022-datacenter-core-smalldisk-g2",
-  "image_version": "latest",
+  "image_version": "20348.230.2109130355",
   "install_latest_windows_updates": "false",
   "location": "westeurope",
   "vm_size": "Standard_D2s_v3",

--- a/image-builder/packer/azure-cbsl-init/windows-ltsc2022-containerd-variables.json
+++ b/image-builder/packer/azure-cbsl-init/windows-ltsc2022-containerd-variables.json
@@ -2,6 +2,8 @@
   "image_offer": "WindowsServer",
   "image_publisher": "MicrosoftWindowsServer",
   "image_sku": "2022-datacenter-core-smalldisk-g2",
+  "image_version": "latest",
+  "install_latest_windows_updates": "false",
   "location": "westeurope",
   "vm_size": "Standard_D2s_v3",
   "image_name": "ws-ltsc2022-containerd-cbsl-init",

--- a/image-builder/packer/azure-cbsl-init/windows-sac2004-containerd-variables.json
+++ b/image-builder/packer/azure-cbsl-init/windows-sac2004-containerd-variables.json
@@ -2,6 +2,8 @@
   "image_offer": "WindowsServer",
   "image_publisher": "MicrosoftWindowsServer",
   "image_sku": "datacenter-core-2004-with-containers-smalldisk-g2",
+  "image_version": "latest",
+  "install_latest_windows_updates": "false",
   "location": "westeurope",
   "vm_size": "Standard_D2s_v3",
   "image_name": "ws-2004-containerd-cbsl-init",

--- a/image-builder/packer/azure-cbsl-init/windows.json
+++ b/image-builder/packer/azure-cbsl-init/windows.json
@@ -14,6 +14,8 @@
     "image_publisher": "{{ user `image_publisher` }}",
     "image_offer": "{{ user `image_offer` }}",
     "image_sku": "{{ user `image_sku` }}",
+    "image_version": "{{ user `image_version` }}",
+    "install_latest_windows_updates": "{{ user `install_latest_windows_updates` }}",
     "location": "{{ user `location` }}",
     "vm_size": "{{ user `vm_size` }}"
   },
@@ -34,6 +36,7 @@
       "image_publisher": "{{ user `image_publisher` }}",
       "image_offer": "{{ user `image_offer` }}",
       "image_sku": "{{ user `image_sku` }}",
+      "image_version": "{{ user `image_version` }}",
 
       "vm_size": "{{ user `vm_size` }}",
       "location": "{{ user `location` }}",
@@ -57,7 +60,8 @@
       "elevated_password": "{{.WinRMPassword}}",
       "type": "powershell",
       "environment_vars": [
-        "CONTAINER_RUNTIME={{ user `container_runtime` }}"
+        "CONTAINER_RUNTIME={{ user `container_runtime` }}",
+        "INSTALL_LATEST_WINDOWS_UPDATES={{ user `install_latest_windows_updates` }}"
       ],
       "script": "0-setup.ps1"
     },

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -295,7 +295,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=ltsc2022
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2022-containerd-cbsl-init:2021.10.20
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2022-containerd-cbsl-init:2021.11.02
         - --cluster-name=capzctrd-ltsc2022-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2022-containerd-flannel-sdnoverlay-stable
@@ -328,7 +328,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=ltsc2022
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2022-containerd-cbsl-init:2021.10.20
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2022-containerd-cbsl-init:2021.11.02
         - --cluster-name=capzctrd-ltsc2022-$(BUILD_ID)
 
 - name: k8s-e2e-sac2004-containerd-flannel-sdnbridge-stable


### PR DESCRIPTION
* Add new Packer config variables:
  * Add `image_version` variable, and use `latest` for all CI images.
  * Add `install_latest_windows_updates` variable. Set this to `false`
     for the current marketplace images since these are updated already.
* Use `20348.230.2109130355` for the LTSC2022 image
* Bump LTSC2022 CI Azure images to `2021.11.02`