### PR TITLE
Bump CI dependencies

### DIFF
--- a/e2e-runner/Dockerfile
+++ b/e2e-runner/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:20.04
 
 ARG GO_VERSION=1.17.3
-ARG CAPI_VERSION=v1.0.0
-ARG KUBECTL_VERSION=v1.22.3
+ARG CAPI_VERSION=v1.0.1
+ARG KUBECTL_VERSION=v1.22.4
 
 # Install system APT packages & dependencies
 RUN apt-get update && \

--- a/e2e-runner/e2e_runner/ci/capz_flannel/flannel/kube-flannel-windows.Dockerfile
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/flannel/kube-flannel-windows.Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE="mcr.microsoft.com/windows/servercore:ltsc2019"
 ARG WINS_VERSION="v0.1.1"
-ARG YQ_VERSION="v4.13.4"
-ARG FLANNEL_VERSION="v0.15.0"
+ARG YQ_VERSION="v4.15.1"
+ARG FLANNEL_VERSION="v0.15.1"
 ARG CNI_PLUGINS_VERSION="v1.0.1"
 ARG FLANNEL_CNI_PLUGIN_VERSION="v1.0"
 
@@ -19,8 +19,8 @@ RUN mkdir -p /k/flannel /opt/cni/bin
 ADD https://github.com/rancher/wins/releases/download/${WINS_VERSION}/wins.exe /wins.exe
 ADD https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_windows_amd64.exe /yq.exe
 ADD https://github.com/coreos/flannel/releases/download/${FLANNEL_VERSION}/flanneld.exe /k/flannel/flanneld.exe
-ADD https://github.com/flannel-io/cni-plugin/releases/download/${FLANNEL_CNI_PLUGIN_VERSION}/flannel.exe /opt/cni/bin/flannel.exe
 ADD https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/cni-plugins-windows-amd64-${CNI_PLUGINS_VERSION}.tgz /tmp/cni-plugins.tgz
+ADD https://github.com/flannel-io/cni-plugin/releases/download/${FLANNEL_CNI_PLUGIN_VERSION}/flannel.exe /opt/cni/bin/flannel.exe
 
 RUN tar -xzvf /tmp/cni-plugins.tgz -C /opt/cni/bin && rm /tmp/cni-plugins.tgz
 

--- a/e2e-runner/e2e_runner/ci/capz_flannel/flannel/kube-flannel-windows.yaml.j2
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/flannel/kube-flannel-windows.yaml.j2
@@ -67,7 +67,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kube-flannel
-        image: k8swin.azurecr.io/flannel-windows:v0.15.0-{{ server_core_tag }}
+        image: k8swin.azurecr.io/flannel-windows:v0.15.1-{{ server_core_tag }}
         command:
         - powershell
         args:

--- a/e2e-runner/e2e_runner/ci/capz_flannel/flannel/kube-flannel.yaml.j2
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/flannel/kube-flannel.yaml.j2
@@ -180,7 +180,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni-plugin
-        image: rancher/mirrored-flannelcni-flannel-cni-plugin:v1.2
+        image: rancher/mirrored-flannelcni-flannel-cni-plugin:v1.0.0
         command:
         - cp
         args:
@@ -191,7 +191,7 @@ spec:
         - name: cni-plugin
           mountPath: /opt/cni/bin
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.15.0
+        image: quay.io/coreos/flannel:v0.15.1
         command:
         - cp
         args:
@@ -205,7 +205,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.15.0
+        image: quay.io/coreos/flannel:v0.15.1
         command:
         - /opt/bin/flanneld
         args:

--- a/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/kube-proxy-windows.Dockerfile
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/kube-proxy-windows.Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE="mcr.microsoft.com/windows/servercore:ltsc2019"
 ARG WINS_VERSION="v0.1.1"
-ARG YQ_VERSION="v4.13.4"
-ARG K8S_VERSION="v1.22.3"
+ARG YQ_VERSION="v4.15.1"
+ARG K8S_VERSION="v1.22.4"
 
 # Linux stage
 FROM --platform=linux/amd64 alpine:latest as prep

--- a/e2e-runner/e2e_runner/constants.py
+++ b/e2e-runner/e2e_runner/constants.py
@@ -1,6 +1,6 @@
 AZURE_LOCATIONS = ["eastus2", "westeurope", "westus2", "southcentralus"]
 
-DEFAULT_KUBERNETES_VERSION = "v1.22.3"
+DEFAULT_KUBERNETES_VERSION = "v1.22.4"
 
 SHARED_IMAGE_GALLERY_TYPE = "shared-image-gallery"
 MANAGED_IMAGE_TYPE = "managed-image"

--- a/e2e-runner/e2e_runner/deployer/capz/control-plane.yaml.j2
+++ b/e2e-runner/e2e_runner/deployer/capz/control-plane.yaml.j2
@@ -153,6 +153,6 @@ spec:
         marketplace:
           publisher: cncf-upstream
           offer: capi
-          sku: k8s-1dot22dot2-ubuntu-2004
+          sku: k8s-1dot22dot4-ubuntu-2004
           version: latest
 {%- endif %}

--- a/image-builder/packer/azure-cbsl-init/PSModules/KubernetesNodeSetup/Common.psm1
+++ b/image-builder/packer/azure-cbsl-init/PSModules/KubernetesNodeSetup/Common.psm1
@@ -7,7 +7,7 @@ $global:ETC_DIR = Join-Path $env:SystemDrive "etc"
 $global:NSSM_DIR = Join-Path $env:ProgramFiles "nssm"
 
 # https://github.com/flannel-io/flannel/releases
-$global:FLANNEL_VERSION = "v0.15.0"
+$global:FLANNEL_VERSION = "v0.15.1"
 
 $global:NSSM_URL = "https://k8stestinfrabinaries.blob.core.windows.net/nssm-mirror/nssm-2.24.zip"
 

--- a/image-builder/packer/azure-cbsl-init/PSModules/KubernetesNodeSetup/KubernetesNodeSetup.psm1
+++ b/image-builder/packer/azure-cbsl-init/PSModules/KubernetesNodeSetup/KubernetesNodeSetup.psm1
@@ -4,7 +4,7 @@ $global:CONTAINERD_DIR = Join-Path $env:SystemDrive "containerd"
 $global:TMP_DIR = Join-Path $env:SystemDrive "tmp"
 
 # https://github.com/containerd/containerd/releases
-$global:CRI_CONTAINERD_VERSION = "v1.6.0-beta.1"
+$global:CRI_CONTAINERD_VERSION = "v1.6.0-beta.3"
 # https://github.com/kubernetes-sigs/cri-tools/releases
 $global:CRICTL_VERSION = "v1.22.0"
 # https://github.com/rancher/wins/releases

--- a/image-builder/packer/azure-cbsl-init/README.md
+++ b/image-builder/packer/azure-cbsl-init/README.md
@@ -36,8 +36,8 @@ The current scripts support the following K8s Windows workers configurations:
     export ACR_USER_NAME="<ACR_USER_NAME>"
     export ACR_USER_PASSWORD="<ACR_USER_PASSWORD>"
 
-    export KUBERNETES_VERSION="v1.22.3"
-    export FLANNEL_VERSION="v0.15.0"
+    export KUBERNETES_VERSION="v1.22.4"
+    export FLANNEL_VERSION="v0.15.1"
     ```
 
 2. Build the container images for the chosen K8s Windows worker configuration:

--- a/image-builder/packer/azure-cbsl-init/windows-ltsc2019-docker-variables.json
+++ b/image-builder/packer/azure-cbsl-init/windows-ltsc2019-docker-variables.json
@@ -1,7 +1,7 @@
 {
   "image_offer": "WindowsServer",
   "image_publisher": "MicrosoftWindowsServer",
-  "image_sku": "2019-datacenter-core-smalldisk-g2",
+  "image_sku": "2019-datacenter-core-with-containers-smalldisk-g2",
   "image_version": "latest",
   "wu_install_latest": "false",
   "wu_install_kb_ids": "",

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -29,7 +29,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.11.16
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.11.26
         - --cluster-name=capzflannel-l2br-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-docker-flannel-winoverlay-master
@@ -62,7 +62,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.11.16
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.11.26
         - --cluster-name=capzflannel-ovrl-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-master
@@ -97,7 +97,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.11.16
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.11.26
         - --cluster-name=capzctrd-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnoverlay-master
@@ -132,7 +132,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.11.16
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.11.26
         - --cluster-name=capzctrd-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-docker-flannel-winbridge-dsr-disabled-master
@@ -165,7 +165,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=False
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.11.16
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.11.26
         - --cluster-name=capzdocker-ltsc2019-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-docker-flannel-winoverlay-dsr-disabled-master
@@ -198,7 +198,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=False
         - --container-runtime=docker
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.11.16
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-docker-cbsl-init:2021.11.26
         - --cluster-name=capzdocker-ltsc2019-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-stable
@@ -230,7 +230,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.11.16
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.11.26
         - --cluster-name=capzctrd-ltsc2019-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnoverlay-stable
@@ -262,7 +262,7 @@ periodics:
         - --win-minion-count=2
         - --enable-win-dsr=True
         - --container-runtime=containerd
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.11.16
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2019-containerd-cbsl-init:2021.11.26
         - --cluster-name=capzctrd-ltsc2019-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2022-containerd-flannel-sdnbridge-stable
@@ -295,7 +295,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=ltsc2022
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2022-containerd-cbsl-init:2021.11.16
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2022-containerd-cbsl-init:2021.11.26
         - --cluster-name=capzctrd-ltsc2022-$(BUILD_ID)
 
 - name: k8s-e2e-ltsc2022-containerd-flannel-sdnoverlay-stable
@@ -328,7 +328,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=ltsc2022
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2022-containerd-cbsl-init:2021.11.16
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-ltsc2022-containerd-cbsl-init:2021.11.26
         - --cluster-name=capzctrd-ltsc2022-$(BUILD_ID)
 
 - name: k8s-e2e-sac2004-containerd-flannel-sdnbridge-stable
@@ -361,7 +361,7 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=2004
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.11.16
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.11.26
         - --cluster-name=capzctrd2004-$(BUILD_ID)
 
 - name: k8s-e2e-sac2004-containerd-flannel-sdnoverlay-stable
@@ -394,5 +394,5 @@ periodics:
         - --enable-win-dsr=True
         - --container-runtime=containerd
         - --base-container-image-tag=2004
-        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.11.16
+        - --win-minion-gallery-image=adtv-capz-win:capz_gallery:ws-2004-containerd-cbsl-init:2021.11.26
         - --cluster-name=capzctrd2004-$(BUILD_ID)

--- a/tools/kube-backup/Dockerfile
+++ b/tools/kube-backup/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ENV K8S_VERSION=1.22.3
+ENV K8S_VERSION=1.22.4
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \


### PR DESCRIPTION
* Use SKU with Containers for LTSC2019 Docker image
* Bump CI dependencies
  * Bump default Kubernetes version to `v1.22.4`
  * Bump `cluster-api` to `v1.0.1`
  * Bump `yq` to `v4.15.1`
  * Bump `flannel` to `v0.15.1`
  * Bump `containerd` to `v1.6.0-beta.3`
* Bump Azure images to `2021.11.26`