### PR TITLE
Set GITHUB_TOKEN to avoid GitHub API rate limit

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -89,3 +89,12 @@ presets:
   - name: windows-private-registry-cred
     mountPath: /etc/docker-cred/
     readOnly: true
+
+- labels:
+    preset-github-readonly-token: "true"
+  env:
+  - name: GITHUB_TOKEN
+    valueFrom:
+      secretKeyRef:
+        key: GITHUB_TOKEN
+        name: github-readonly-token

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -4,6 +4,7 @@ periodics:
   always_run: true
   decorate: true
   labels:
+    preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
     preset-windows-private-registry-cred: "true"
@@ -35,6 +36,7 @@ periodics:
   always_run: true
   decorate: true
   labels:
+    preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
     preset-windows-private-registry-cred: "true"
@@ -66,6 +68,7 @@ periodics:
   always_run: true
   decorate: true
   labels:
+    preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
     preset-windows-private-registry-cred: "true"
@@ -92,6 +95,7 @@ periodics:
   always_run: true
   decorate: true
   labels:
+    preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
     preset-windows-private-registry-cred: "true"
@@ -119,6 +123,7 @@ periodics:
   always_run: true
   decorate: true
   labels:
+    preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
     preset-windows-private-registry-cred: "true"
@@ -145,6 +150,7 @@ periodics:
   always_run: true
   decorate: true
   labels:
+    preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
     preset-windows-private-registry-cred: "true"
@@ -172,6 +178,7 @@ periodics:
   always_run: true
   decorate: true
   labels:
+    preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
     preset-windows-private-registry-cred: "true"
@@ -199,6 +206,7 @@ periodics:
   always_run: true
   decorate: true
   labels:
+    preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
     preset-windows-private-registry-cred: "true"
@@ -226,6 +234,7 @@ periodics:
   always_run: true
   decorate: true
   labels:
+    preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
     preset-windows-private-registry-cred: "true"
@@ -253,6 +262,7 @@ periodics:
   always_run: true
   decorate: true
   labels:
+    preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
     preset-windows-private-registry-cred: "true"


### PR DESCRIPTION
Without this, the `clusterctl init` command might fail with:
```
rate limit for github api has been reached.
Please wait one hour or get a personal API tokens a assign it to the GITHUB_TOKEN environment variable
```

The token used is a simple personal access token with `public_repo` access.