### PR TITLE
Temporarily disable WinDSR for WS2022 + sdnbridge and bump K8s version

### DIFF
--- a/e2e-runner/Dockerfile
+++ b/e2e-runner/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 ARG CAPI_VERSION=v1.1.0
-ARG KUBECTL_VERSION=v1.23.0
+ARG KUBECTL_VERSION=v1.23.3
 
 # Install system APT packages & dependencies
 RUN apt-get update && \

--- a/e2e-runner/e2e_runner/ci/capz_flannel/Makefile
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/Makefile
@@ -1,6 +1,6 @@
 REGISTRY := k8swin.azurecr.io
 FLANNEL_VERSION ?= v0.15.1
-KUBERNETES_VERSION ?= v1.23.0
+KUBERNETES_VERSION ?= v1.23.3
 
 .PHONY: all
 all: buildx-flannel buildx-kube-proxy

--- a/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/kube-proxy-windows.Dockerfile
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/kube-proxy-windows.Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE="mcr.microsoft.com/powershell:lts-nanoserver-1809"
 ARG WINS_VERSION="v0.1.1"
 ARG YQ_VERSION="v4.16.1"
-ARG K8S_VERSION="v1.23.0"
+ARG K8S_VERSION="v1.23.3"
 
 # Linux stage
 FROM --platform=linux/amd64 alpine:latest as prep

--- a/e2e-runner/e2e_runner/constants.py
+++ b/e2e-runner/e2e_runner/constants.py
@@ -1,6 +1,6 @@
 AZURE_LOCATIONS = ["eastus2", "westeurope", "westus2", "southcentralus"]
 
-DEFAULT_KUBERNETES_VERSION = "v1.23.0"
+DEFAULT_KUBERNETES_VERSION = "v1.23.3"
 
 FLANNEL_MODE_OVERLAY = "overlay"
 FLANNEL_MODE_L2BRIDGE = "host-gw"

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -253,6 +253,7 @@ periodics:
         - --build=sdncnibins
         - capz_flannel
         - --flannel-mode=host-gw
+        - --enable-win-dsr=False
         - --container-runtime=containerd
         - --win-os=ltsc2022
         - --cluster-name=capzctrd-ltsc2022-$(BUILD_ID)

--- a/tools/kube-backup/Dockerfile
+++ b/tools/kube-backup/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-ENV K8S_VERSION=1.23.0
+ENV K8S_VERSION=v1.23.3
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
@@ -12,7 +12,7 @@ RUN apt-get update && \
 	rm -rf /var/lib/apt/lists/*
 
 # Install kubernetes client
-RUN curl -fsSL https://dl.k8s.io/v${K8S_VERSION}/kubernetes-client-linux-amd64.tar.gz -o /tmp/k8s.tar.gz && \
+RUN curl -fsSL https://dl.k8s.io/${K8S_VERSION}/kubernetes-client-linux-amd64.tar.gz -o /tmp/k8s.tar.gz && \
 	tar -zxf /tmp/k8s.tar.gz -C /tmp/ && \
 	mv /tmp/kubernetes/client/bin/kubectl /usr/local/bin/kubectl && \
 	rm -rf /tmp/k8s.tar.gz /tmp/kubernetes


### PR DESCRIPTION
* Disable WinDSR for WS2022 + sdnbridge.
  * There's a known regression with the WinDSR and WS2022 + sdnbridge.
* Bump default Kubernetes version to `v1.23.3`