### PR TITLE
Add flake attempts runner parameter & other updates

### DIFF
--- a/e2e-runner/e2e_runner/base.py
+++ b/e2e-runner/e2e_runner/base.py
@@ -105,25 +105,28 @@ class CI(object):
     def _run_tests(self):
         # Invokes kubetest
         self.logging.info("Running tests on env.")
-        cmd = ["kubetest"]
-        cmd.append("--check-version-skew=false")
-        cmd.append("--ginkgo-parallel=%s" % self.opts.parallel_test_nodes)
-        cmd.append("--verbose-commands=true")
-        cmd.append("--provider=skeleton")
-        cmd.append("--test")
-        cmd.append("--dump=%s" % self.opts.artifacts_directory)
-        cmd.append(
-            ('--test_args=--ginkgo.flakeAttempts=1 '
-             '--test.timeout=2h '
-             '--num-nodes=2 --ginkgo.noColor '
-             '--ginkgo.dryRun=false '
-             '--node-os-distro=windows '
-             '--prepull-images=true '
-             '--ginkgo.focus=%(focus)s '
-             '--ginkgo.skip=%(skip)s') % {
-                 "focus": self.opts.test_focus_regex,
-                 "skip": self.opts.test_skip_regex})
+        test_args = (
+            "--test.timeout=2h "
+            "--num-nodes=2 "
+            "--node-os-distro=windows "
+            "--prepull-images=true "
+            "--ginkgo.noColor "
+            "--ginkgo.dryRun=false "
+            f"--ginkgo.flakeAttempts={self.opts.flake_attempts} "
+            f"--ginkgo.focus={self.opts.test_focus_regex} "
+            f"--ginkgo.skip={self.opts.test_skip_regex}"
+        )
+        cmd = [
+            "kubetest",
+            "--check-version-skew=false",
+            "--verbose-commands=true",
+            "--provider=skeleton",
+            "--test",
+            f"--ginkgo-parallel={self.opts.parallel_test_nodes}",
+            f"--dump={self.opts.artifacts_directory}",
+            f"--test_args={test_args}",
+        ]
         docker_config_file = os.environ.get("DOCKER_CONFIG_FILE")
         if docker_config_file:
-            cmd.append(' --docker-config-file=%s' % docker_config_file)
+            cmd.append(f" --docker-config-file={docker_config_file}")
         return subprocess.call(cmd, cwd=e2e_utils.get_k8s_folder())

--- a/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
@@ -101,7 +101,7 @@ class CapzFlannelCI(e2e_base.CI):
         remote_script_path = os.path.join(
             "/tmp", os.path.basename(local_script_path))
         remote_cmd = remote_script_path
-        remote_logs_archive = "/tmp/logs.zip"
+        remote_logs_archive = "/tmp/logs.tgz"
         for node_address in self.deployer.windows_private_addresses:
             try:
                 self._collect_logs(
@@ -121,7 +121,7 @@ class CapzFlannelCI(e2e_base.CI):
         remote_script_path = os.path.join(
             "/tmp", os.path.basename(local_script_path))
         remote_cmd = f"sudo bash {remote_script_path}"
-        remote_logs_archive = "/tmp/logs.tar.gz"
+        remote_logs_archive = "/tmp/logs.tgz"
         for node_address in self.deployer.linux_private_addresses:
             try:
                 self._collect_logs(

--- a/e2e-runner/e2e_runner/cli/run_ci.py
+++ b/e2e-runner/e2e_runner/cli/run_ci.py
@@ -31,10 +31,10 @@ class RunCI(Command):
 
         p.add_argument(
             "--parallel-test-nodes",
-            default=1)
+            default=8)
         p.add_argument(
             "--flake-attempts",
-            default=1,
+            default=2,
             help="Number of attempts to run the flake tests."
         )
         p.add_argument(

--- a/e2e-runner/e2e_runner/cli/run_ci.py
+++ b/e2e-runner/e2e_runner/cli/run_ci.py
@@ -33,6 +33,11 @@ class RunCI(Command):
             "--parallel-test-nodes",
             default=1)
         p.add_argument(
+            "--flake-attempts",
+            default=1,
+            help="Number of attempts to run the flake tests."
+        )
+        p.add_argument(
             "--repo-list",
             default="https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list",  # noqa
             help="Repo list with registries for test images.")

--- a/e2e-runner/e2e_runner/scripts/collect-logs.sh
+++ b/e2e-runner/e2e_runner/scripts/collect-logs.sh
@@ -42,4 +42,4 @@ get_k8s_logs() {
 get_systemd_logs
 get_k8s_logs
 
-tar -czvf /tmp/logs.tar.gz -C $LOGS_DIR .
+tar -czvf /tmp/logs.tgz -C $LOGS_DIR .

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -12,10 +12,7 @@ periodics:
     containers:
     - image: e2eteam/k8s-e2e-runner:latest
       imagePullPolicy: Always
-      command:
-        - /workspace/entrypoint.sh
       args:
-        - --parallel-test-nodes=4
         - --repo-list=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-master
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
@@ -44,10 +41,7 @@ periodics:
     containers:
     - image: e2eteam/k8s-e2e-runner:latest
       imagePullPolicy: Always
-      command:
-        - /workspace/entrypoint.sh
       args:
-        - --parallel-test-nodes=4
         - --repo-list=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list-master
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
@@ -76,10 +70,7 @@ periodics:
     containers:
     - image: e2eteam/k8s-e2e-runner:latest
       imagePullPolicy: Always
-      command:
-        - /workspace/entrypoint.sh
       args:
-        - --parallel-test-nodes=4
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
@@ -103,10 +94,7 @@ periodics:
     containers:
     - image: e2eteam/k8s-e2e-runner:latest
       imagePullPolicy: Always
-      command:
-        - /workspace/entrypoint.sh
       args:
-        - --parallel-test-nodes=4
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
@@ -131,10 +119,7 @@ periodics:
     containers:
     - image: e2eteam/k8s-e2e-runner:latest
       imagePullPolicy: Always
-      command:
-        - /workspace/entrypoint.sh
       args:
-        - --parallel-test-nodes=4
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
@@ -158,10 +143,7 @@ periodics:
     containers:
     - image: e2eteam/k8s-e2e-runner:latest
       imagePullPolicy: Always
-      command:
-        - /workspace/entrypoint.sh
       args:
-        - --parallel-test-nodes=4
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
@@ -186,10 +168,7 @@ periodics:
     containers:
     - image: e2eteam/k8s-e2e-runner:latest
       imagePullPolicy: Always
-      command:
-        - /workspace/entrypoint.sh
       args:
-        - --parallel-test-nodes=4
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
@@ -214,10 +193,7 @@ periodics:
     containers:
     - image: e2eteam/k8s-e2e-runner:latest
       imagePullPolicy: Always
-      command:
-        - /workspace/entrypoint.sh
       args:
-        - --parallel-test-nodes=4
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
@@ -242,10 +218,7 @@ periodics:
     containers:
     - image: e2eteam/k8s-e2e-runner:latest
       imagePullPolicy: Always
-      command:
-        - /workspace/entrypoint.sh
       args:
-        - --parallel-test-nodes=4
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice
@@ -271,10 +244,7 @@ periodics:
     containers:
     - image: e2eteam/k8s-e2e-runner:latest
       imagePullPolicy: Always
-      command:
-        - /workspace/entrypoint.sh
       args:
-        - --parallel-test-nodes=4
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
         - --test-focus-regex=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[sig-apps\].CronJob|\[sig-api-machinery\].ResourceQuota|\[sig-network\].EndpointSlice


### PR DESCRIPTION
* Add --flake-attempts parameter.
  * Also, cleanup `_run_tests` function.
* Update default runner params
  * Use 8 parallel test nodes, by default
  * Allow 2 flake attempts for the tests, by default
* Update jobs/sig-windows-networking.yaml
  * Remove explicit container command.
    This was already set in the container image as `ENTRYPOINT`.
  * Remove explicit `--parallel-test-nodes` param, and rely on the
    default value.
* Update logs collection
  * Collect Docker logs only if service is available.
  * Use `tgz` logs archive on both Linux and Windows.
