### PR TITLE
Add control-plane machine health check

### DIFF
--- a/e2e-runner/e2e_runner/deployer/capz/control-plane.yaml.j2
+++ b/e2e-runner/e2e_runner/deployer/capz/control-plane.yaml.j2
@@ -1,4 +1,19 @@
 ---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: {{ cluster_name }}-control-plane-mhc
+spec:
+  clusterName: {{ cluster_name }}
+  nodeStartupTimeout: 10m
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/control-plane: ""
+  unhealthyConditions:
+    - type: Ready
+      status: Unknown
+      timeout: 5m
+---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
 metadata:


### PR DESCRIPTION
Add `MachineHealthCheck` resource for the control-plane machine.
In case of deployment failure, the control-plane machine will be
re-created.