### PR TITLE
Use conformance image for E2E tests & other updates

### DIFF
--- a/e2e-runner/e2e_runner/base.py
+++ b/e2e-runner/e2e_runner/base.py
@@ -42,41 +42,15 @@ class CI(object):
         self.logging.info("CI Down: Default NOOP")
 
     def test(self):
-        self._prepare_test_env()
         self._prepare_tests()
         return self._run_tests()
 
-    def _prepare_test_env(self):
-        # Should be implemented by each CI type sets environment variables
-        # and other settings and copies over kubeconfig. Repo list will be
-        # downloaded in _prepare_tests() as that would be less likely to be
-        # reimplemented.
-        #
-        # Necessary env settings:
-        # KUBE_MASTER=local
-        # KUBE_MASTER_IP=dns-name-of-node
-        # KUBE_MASTER_URL=https://$KUBE_MASTER_IP
-        # KUBECONFIG=/path/to/kube/config
-        # KUBE_TEST_REPO_LIST= will be set in _prepare_tests
-        self.logging.info("CI Prepare Test Env: Default NOOP")
-
-    def _setup_kubetest(self):
-        self.logging.info("Setup Kubetest")
-        e2e_utils.clone_git_repo(
-            "https://github.com/kubernetes/test-infra", "master",
-            "/tmp/test-infra")
-        e2e_utils.run_shell_cmd(
-            cmd=["go", "install", "./kubetest"],
-            cwd="/tmp/test-infra", env={"GO111MODULE": "on"})
-
-    def _prepare_tests(self):
-        # Sets KUBE_TEST_REPO_LIST
-        # Builds tests
-        # Taints linux nodes so that no pods will be scheduled there.
+    @e2e_utils.retry_on_error()
+    def _label_linux_nodes_no_schedule(self):
         kubectl = e2e_utils.get_kubectl_bin()
         out, _ = e2e_utils.run_shell_cmd([
             kubectl, "get", "nodes", "--selector",
-            "beta.kubernetes.io/os=linux", "--no-headers", "-o",
+            "kubernetes.io/os=linux", "--no-headers", "-o",
             "custom-columns=NAME:.metadata.name"
         ])
         linux_nodes = out.decode().strip().split("\n")
@@ -89,6 +63,21 @@ class CI(object):
                 kubectl, "label", "nodes", "--overwrite", node,
                 "node-role.kubernetes.io/master=NoSchedule"
             ])
+
+    def _prepare_tests(self):
+        # - Taints linux nodes so that no pods will be scheduled there.
+        # - Sets the KUBE_TEST_REPO_LIST env variable.
+        # - Builds tests.
+        # - Builds kubetest.
+        #
+        # Necessary env settings for the tests:
+        # KUBE_MASTER=local
+        # KUBE_MASTER_IP=dns-name-of-node
+        # KUBE_MASTER_URL=https://$KUBE_MASTER_IP
+        # KUBECONFIG=/path/to/kube/config
+        # KUBE_TEST_REPO_LIST=/tmp/repo-list
+        #
+        self._label_linux_nodes_no_schedule()
         self.logging.info("Downloading repo-list")
         e2e_utils.download_file(self.opts.repo_list, "/tmp/repo-list")
         os.environ["KUBE_TEST_REPO_LIST"] = "/tmp/repo-list"
@@ -100,7 +89,13 @@ class CI(object):
         e2e_utils.run_shell_cmd(
             cmd=["make", 'WHAT="vendor/github.com/onsi/ginkgo/ginkgo"'],
             cwd=e2e_utils.get_k8s_folder())
-        self._setup_kubetest()
+        self.logging.info("Setup Kubetest")
+        e2e_utils.clone_git_repo(
+            "https://github.com/kubernetes/test-infra", "master",
+            "/tmp/test-infra")
+        e2e_utils.run_shell_cmd(
+            cmd=["go", "install", "./kubetest"],
+            cwd="/tmp/test-infra", env={"GO111MODULE": "on"})
 
     def _run_tests(self):
         # Invokes kubetest

--- a/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
@@ -342,7 +342,7 @@ class CapzFlannelCI(e2e_base.CI):
             f"{remote_k8s_path}/", local_k8s_path)
         # Build Linux DaemonSet container images
         self.logging.info("Building K8s Linux DaemonSet container images")
-        cmd = ("KUBE_FASTBUILD=true KUBE_BUILD_CONFORMANCE=n "
+        cmd = ("KUBE_FASTBUILD=true KUBE_BUILD_CONFORMANCE=y "
                "make quick-release-images")
         self.deployer.run_cmd_on_bootstrap_vm([cmd], cwd=remote_k8s_path)
         # Discover the K8s version built
@@ -374,7 +374,7 @@ class CapzFlannelCI(e2e_base.CI):
             script.append(f"cp {win_bin_path} {windows_bin_dir}")
         images_names = [
             "kube-apiserver.tar", "kube-controller-manager.tar",
-            "kube-proxy.tar", "kube-scheduler.tar"
+            "kube-proxy.tar", "kube-scheduler.tar", "conformance-amd64.tar"
         ]
         for image_name in images_names:
             image_path = "{}/{}/{}".format(

--- a/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
@@ -63,10 +63,6 @@ class CapzFlannelCI(e2e_base.CI):
             builder_mapping.get(bins, noop_func)()
             self.deployer.bins_built.append(bins)
 
-        # Setup the E2E tests and the kubetest
-        self._setup_e2e_tests()
-        self._setup_kubetest()
-
     def up(self):
         start = time.time()
         self.deployer.up()
@@ -145,62 +141,140 @@ class CapzFlannelCI(e2e_base.CI):
     def _setup_kubeconfig(self):
         os.environ["KUBECONFIG"] = self.deployer.capz_kubeconfig_path
 
-    def _setup_kubetest(self):
-        self.logging.info("Setup Kubetest")
-        remote_dirname = os.path.dirname(self.deployer.remote_test_infra_path)
-        self.deployer.run_cmd_on_bootstrap_vm(
-            cmd=[f"mkdir -p {remote_dirname}"])
-        self.deployer.remote_clone_git_repo(
-            "https://github.com/kubernetes/test-infra.git",
-            "master",
-            self.deployer.remote_test_infra_path)
-        self.deployer.run_cmd_on_bootstrap_vm(
-            cmd=['GO111MODULE=on go install ./kubetest'],
-            cwd=self.deployer.remote_test_infra_path)
-        local_gopath_bin_path = os.path.join(e2e_utils.get_go_path(), "bin")
-        os.makedirs(local_gopath_bin_path, exist_ok=True)
-        self.deployer.download_from_bootstrap_vm(
-            f"{self.deployer.remote_go_path}/bin/kubetest",
-            f"{local_gopath_bin_path}/kubetest")
+    def _conformance_image_tag(self):
+        if "k8sbins" in self.deployer.bins_built:
+            return self.kubernetes_version.replace("+", "_")
+        return self.kubernetes_version
 
-    def _setup_e2e_tests(self):
-        self.logging.info("Setup Kubernetes E2E tests")
-        self.deployer.remote_clone_git_repo(
-            self.opts.k8s_repo, self.opts.k8s_branch,
-            self.deployer.remote_k8s_path)
-        self.logging.info("Building tests")
-        self.deployer.run_cmd_on_bootstrap_vm(
-            cmd=['make WHAT="test/e2e/e2e.test"'],
-            cwd=self.deployer.remote_k8s_path)
-        self.logging.info("Building ginkgo")
-        self.deployer.run_cmd_on_bootstrap_vm(
-            cmd=['make WHAT="vendor/github.com/onsi/ginkgo/ginkgo"'],
-            cwd=self.deployer.remote_k8s_path)
-        local_k8s_path = e2e_utils.get_k8s_folder()
-        os.makedirs(local_k8s_path, exist_ok=True)
-        self.deployer.download_from_bootstrap_vm(
-            f"{self.deployer.remote_k8s_path}/", local_k8s_path)
+    def _conformance_image_pull_cmd(self):
+        if "k8sbins" in self.deployer.bins_built:
+            # Image is already imported as part of the userdata script.
+            return ""
+        cmd = [
+            "sudo", "ctr", "-n", "k8s.io",
+            "image", "pull",
+            f"k8s.gcr.io/conformance:{self._conformance_image_tag()}"
+        ]
+        return " ".join(cmd)
+
+    def _conformance_tests_cmd(self):
+        cmd = ["sudo", "ctr", "-n", "k8s.io", "run", "--rm", "--net-host"]
+        mounts = [
+            {
+                "src": "/tmp/output",
+                "dst": "/output",
+                "mode": "rw",
+            },
+            {
+                "src": "/tmp/repo-list",
+                "dst": "/tmp/repo-list",
+                "mode": "ro",
+            },
+            {
+                "src": "/etc/kubernetes/admin.conf",
+                "dst": "/tmp/kubeconfig",
+                "mode": "ro",
+            },
+        ]
+        env = {
+            "KUBE_TEST_REPO_LIST": "/tmp/repo-list",
+        }
+        ginkgoFlags = {
+            "noColor": "true",
+            "progress": "true",
+            "trace": "true",
+            "v": "true",
+            "slowSpecThreshold": "120.0",
+            "flakeAttempts": f"{self.opts.flake_attempts}",
+            "nodes": self.opts.parallel_test_nodes,
+            "focus": f"'{self.opts.test_focus_regex}'",
+            "skip": f"'{self.opts.test_skip_regex}'",
+        }
+        e2eFlags = {
+            "kubeconfig": "/tmp/kubeconfig",
+            "provider": "skeleton",
+            "report-dir": "/output",
+            "e2e-output-dir": "/output/e2e-output",
+            "test.timeout": "2h",
+            "num-nodes": "2",
+            "node-os-distro": "windows",
+            "prepull-images": "true",
+            "disable-log-dump": "true",
+        }
+        docker_config_file = os.environ.get("DOCKER_CONFIG_FILE")
+        if docker_config_file:
+            mounts.append({
+                "src": "/tmp/docker-creds-config.json",
+                "dst": "/tmp/docker-creds-config.json",
+                "mode": "ro",
+            })
+            e2eFlags["docker-config-file"] = "/tmp/docker-creds-config.json"
+        for m in mounts:
+            src = m["src"]
+            dst = m["dst"]
+            mode = m.get("mode", "rw")
+            opts = f"rbind:{mode}"
+            cmd.extend([
+                "--mount",
+                f"type=bind,src={src},dst={dst},options={opts}"
+            ])
+        for key in env:
+            cmd.extend([
+                "--env",
+                f"{key}={env[key]}"
+            ])
+        ginkgoArgs = [f"--{k}={v}" for k, v in ginkgoFlags.items()]
+        e2eArgs = [f"--{k}={v}" for k, v in e2eFlags.items()]
+        cmd.extend([
+            f"k8s.gcr.io/conformance:{self._conformance_image_tag()}",
+            "conformance_tests",
+            "/usr/local/bin/ginkgo",
+            *ginkgoArgs,
+            "/usr/local/bin/e2e.test",
+            "--",
+            *e2eArgs,
+        ])
+        return " ".join(cmd)
 
     def _prepare_tests(self):
-        kubectl = e2e_utils.get_kubectl_bin()
-        out, _ = e2e_utils.run_shell_cmd([
-            kubectl, "get", "nodes", "--selector",
-            "beta.kubernetes.io/os=linux", "--no-headers", "-o",
-            "custom-columns=NAME:.metadata.name"
-        ])
-        linux_nodes = out.decode().strip().split("\n")
-        for node in linux_nodes:
-            e2e_utils.run_shell_cmd([
-                kubectl, "taint", "nodes", "--overwrite", node,
-                "node-role.kubernetes.io/master=:NoSchedule"
-            ])
-            e2e_utils.run_shell_cmd([
-                kubectl, "label", "nodes", "--overwrite", node,
-                "node-role.kubernetes.io/master=NoSchedule"
-            ])
+        self._label_linux_nodes_no_schedule()
+        self._prepull_images()
         self.logging.info("Downloading repo-list")
         e2e_utils.download_file(self.opts.repo_list, "/tmp/repo-list")
-        os.environ["KUBE_TEST_REPO_LIST"] = "/tmp/repo-list"
+        self._upload_to_node(
+            "/tmp/repo-list", "/tmp/repo-list",
+            [self.deployer.master_public_address])
+        self._run_node_cmd(
+            "mkdir -p /tmp/output",
+            [self.deployer.master_public_address])
+        docker_config_file = os.environ.get("DOCKER_CONFIG_FILE")
+        if docker_config_file:
+            self._upload_to_node(
+                docker_config_file, "/tmp/docker-creds-config.json",
+                [self.deployer.master_public_address])
+
+    def _run_tests(self):
+        ssh_kwargs = {
+            "ssh_user": "capi",
+            "ssh_address": self.deployer.master_public_address,
+            "ssh_key_path": os.environ["SSH_KEY"],
+        }
+        tests_cmd = [
+            self._conformance_image_pull_cmd(),
+            self._conformance_tests_cmd(),
+        ]
+        tests_timeout = 150 * 60  # 150 minutes
+        try:
+            self.logging.info("Tests cmd\n%s", "\n".join(tests_cmd))
+            e2e_utils.run_remote_ssh_cmd(
+                cmd=tests_cmd, timeout=tests_timeout, **ssh_kwargs)
+        except Exception:
+            return 1
+        finally:
+            e2e_utils.rsync_download(
+                "/tmp/output/", self.opts.artifacts_directory,
+                delete=False, **ssh_kwargs)
+        return 0
 
     def _upload_to_node(self, local_path, remote_path, node_addresses):
         for node_address in node_addresses:
@@ -210,15 +284,6 @@ class CapzFlannelCI(e2e_base.CI):
     def _run_node_cmd(self, cmd, node_addresses):
         for node_address in node_addresses:
             self.deployer.run_cmd_on_k8s_node(cmd, node_address)
-
-    def _prepare_test_env(self):
-        self.logging.info("Preparing test env")
-        os.environ["KUBE_MASTER"] = "local"
-        os.environ["KUBE_MASTER_IP"] = self.deployer.master_public_address
-        os.environ["KUBE_MASTER_URL"] = "https://{}:{}".format(
-            self.deployer.master_public_address,
-            self.deployer.master_public_port)
-        self._prepull_images()
 
     def _prepull_images(self, timeout=3600):
         prepull_yaml_path = "/tmp/prepull-windows-images.yaml"
@@ -319,7 +384,6 @@ class CapzFlannelCI(e2e_base.CI):
 
     def _build_k8s_artifacts(self):
         # Clone Kubernetes git repository
-        local_k8s_path = e2e_utils.get_k8s_folder()
         remote_k8s_path = self.deployer.remote_k8s_path
         self.deployer.remote_clone_git_repo(
             self.opts.k8s_repo, self.opts.k8s_branch, remote_k8s_path)
@@ -329,17 +393,12 @@ class CapzFlannelCI(e2e_base.CI):
                'WHAT="cmd/kubectl cmd/kubelet cmd/kubeadm" '
                'KUBE_BUILD_PLATFORMS="linux/amd64"')
         self.deployer.run_cmd_on_bootstrap_vm([cmd], cwd=remote_k8s_path)
-        del os.environ["KUBECTL_PATH"]
         # Build Windows binaries
         self.logging.info("Building K8s Windows binaries")
         cmd = ('make '
                'WHAT="cmd/kubectl cmd/kubelet cmd/kubeadm cmd/kube-proxy" '
                'KUBE_BUILD_PLATFORMS="windows/amd64"')
         self.deployer.run_cmd_on_bootstrap_vm([cmd], cwd=remote_k8s_path)
-        # Download binaries from the bootstrap VM
-        os.makedirs(local_k8s_path, exist_ok=True)
-        self.deployer.download_from_bootstrap_vm(
-            f"{remote_k8s_path}/", local_k8s_path)
         # Build Linux DaemonSet container images
         self.logging.info("Building K8s Linux DaemonSet container images")
         cmd = ("KUBE_FASTBUILD=true KUBE_BUILD_CONFORMANCE=y "
@@ -347,8 +406,10 @@ class CapzFlannelCI(e2e_base.CI):
         self.deployer.run_cmd_on_bootstrap_vm([cmd], cwd=remote_k8s_path)
         # Discover the K8s version built
         kubeadm_bin = os.path.join(
-            local_k8s_path, "_output/local/bin/linux/amd64/kubeadm")
-        out, _ = e2e_utils.run_shell_cmd([kubeadm_bin, "version", "-o=short"])
+            remote_k8s_path, "_output/local/bin/linux/amd64/kubeadm")
+        out, _ = self.deployer.run_cmd_on_bootstrap_vm(
+            cmd=[f"{kubeadm_bin} version -o=short"],
+            timeout=30, return_result=True)
         self.kubernetes_version = out.decode().strip()
         self.deployer.kubernetes_version = self.kubernetes_version
         # Copy artifacts to their own directory on the bootstrap VM
@@ -382,6 +443,10 @@ class CapzFlannelCI(e2e_base.CI):
                 "_output/release-images/amd64",
                 image_name)
             script.append(f"cp {image_path} {images_dir}")
+        script.append(
+            "mv "
+            f"{images_dir}/conformance-amd64.tar "
+            f"{images_dir}/conformance.tar")
         script.append(f"chmod 644 {images_dir}/*")
         self.deployer.run_cmd_on_bootstrap_vm(script)
 

--- a/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
@@ -74,8 +74,6 @@ class CapzFlannelCI(e2e_base.CI):
         self._add_flannel_cni()
         self.deployer.wait_windows_agents()
         self.deployer.setup_ssh_config()
-        if "k8sbins" in self.deployer.bins_built:
-            self._upload_kube_proxy_windows_bin()
         self._add_kube_proxy_windows()
         self._wait_for_ready_pods()
         elapsed = time.time() - start
@@ -276,16 +274,6 @@ class CapzFlannelCI(e2e_base.CI):
             self.kubectl, "wait", "--for=condition=Ready",
             "--timeout", "10m", "pods", "--all", "--all-namespaces"
         ])
-
-    def _upload_kube_proxy_windows_bin(self):
-        self.logging.info("Uploading the kube-proxy.exe to the Windows agents")
-        win_node_addresses = self.deployer.windows_private_addresses
-        kube_proxy_bin = "{}/{}/kube-proxy.exe".format(
-            e2e_utils.get_k8s_folder(),
-            "_output/local/bin/windows/amd64")
-        self._run_node_cmd("mkdir -force /build", win_node_addresses)
-        self._upload_to_node(
-            kube_proxy_bin, "/build/kube-proxy.exe", win_node_addresses)
 
     def _add_kube_proxy_windows(self):
         context = {

--- a/e2e-runner/e2e_runner/cli/run_ci.py
+++ b/e2e-runner/e2e_runner/cli/run_ci.py
@@ -31,7 +31,7 @@ class RunCI(Command):
 
         p.add_argument(
             "--parallel-test-nodes",
-            default=8)
+            default=2)
         p.add_argument(
             "--flake-attempts",
             default=2,

--- a/e2e-runner/e2e_runner/cli/run_ci.py
+++ b/e2e-runner/e2e_runner/cli/run_ci.py
@@ -52,6 +52,12 @@ class RunCI(Command):
         p.add_argument(
             "--test-skip-regex",
             default="\\[LinuxOnly\\]")
+        p.add_argument(
+            "--retain-testing-env",
+            type=e2e_utils.str2bool,
+            default=False,
+            help="Retain the testing environment, if the conformance tests "
+                 "failed. Useful for debugging purposes.")
 
         p.add_argument(
             "--k8s-repo",
@@ -187,9 +193,9 @@ class RunCI(Command):
             raise
         finally:
             ci.collect_logs()
-            if tests_exit_code != 0:
+            if tests_exit_code != 0 and args.retain_testing_env:
                 self.logging.warning(
-                    "Conformance tests failed. Retain the resource group "
+                    "Conformance tests failed. Retain the testing env "
                     "for debugging purposes.")
             else:
                 ci.down()

--- a/e2e-runner/e2e_runner/deployer/capz/control-plane.yaml.j2
+++ b/e2e-runner/e2e_runner/deployer/capz/control-plane.yaml.j2
@@ -112,7 +112,7 @@ spec:
       - /var/lib/etcddisk
     preKubeadmCommands:
     - curl -Lo /run/kubeadm/kubeadm-bootstrap.sh http://{{ bootstrap_vm_address }}/scripts/kubeadm-bootstrap.sh
-    - bash /run/kubeadm/kubeadm-bootstrap.sh http://{{ bootstrap_vm_address }} {{ kubernetes_version }} {{ k8s_bins }}
+    - bash /run/kubeadm/kubeadm-bootstrap.sh --ci-packages-base-url http://{{ bootstrap_vm_address }} --ci-version {{ kubernetes_version }} --k8s-bins-built {{ k8s_bins }}
 {%- if flannel_mode == "overlay" %}
     postKubeadmCommands:
     - netplan apply

--- a/e2e-runner/e2e_runner/scripts/kubeadm-bootstrap.ps1
+++ b/e2e-runner/e2e_runner/scripts/kubeadm-bootstrap.ps1
@@ -127,6 +127,8 @@ function Update-Kubernetes {
     foreach($bin in $binaries) {
         Start-FileDownload "$CIPackagesBaseURL/$CIVersion/bin/windows/amd64/$bin" "$KUBERNETES_DIR\$bin"
     }
+    New-Item -ItemType Directory -Force -Path $BUILD_DIR
+    Start-FileDownload "$CIPackagesBaseURL/$CIVersion/bin/windows/amd64/kube-proxy.exe" "$BUILD_DIR\kube-proxy.exe"
 }
 
 function Update-SDNCNI {

--- a/e2e-runner/e2e_runner/scripts/kubeadm-bootstrap.sh
+++ b/e2e-runner/e2e_runner/scripts/kubeadm-bootstrap.sh
@@ -1,16 +1,28 @@
 #!/usr/bin/env bash
-set -o nounset
 set -o pipefail
 set -o errexit
 
-if [[ $# -ne 3 ]]; then
-    echo "USAGE: $0 <CI_PACKAGES_BASE_URL> <CI_VERSION> <K8S_BINS_BUILT>"
-    exit 1
+while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
+    case $1 in
+        --ci-packages-base-url )
+            shift; CI_PACKAGES_BASE_URL="$1"
+            ;;
+        --ci-version )
+            shift; CI_VERSION="$1"
+            ;;
+        --k8s-bins-built )
+            shift; K8S_BINS_BUILT="$1"
+            ;;
+    esac
+    shift
+done
+if [[ "$1" == '--' ]]; then
+    shift
 fi
 
-CI_PACKAGES_BASE_URL=$1
-CI_VERSION=$2
-K8S_BINS_BUILT=$3
+if [[ -z $CI_PACKAGES_BASE_URL ]]; then echo "param --ci-packages-base-url is not set"; exit 1; fi
+if [[ -z $CI_VERSION ]]; then echo "param --ci-version is not set"; exit 1; fi
+if [[ -z $K8S_BINS_BUILT ]]; then echo "param --k8s-bins-built is not set"; exit 1; fi
 
 run_cmd_with_retry() {
     local RETRIES=$1
@@ -34,7 +46,7 @@ run_cmd_with_retry() {
 
 update_k8s() {
     CI_PACKAGES=("kubectl" "kubelet" "kubeadm")
-    CI_IMAGES=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler")
+    CI_IMAGES=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler" "conformance-amd64")
 
     echo "Updating Kubernetes to version: $CI_VERSION"
 

--- a/e2e-runner/e2e_runner/scripts/kubeadm-bootstrap.sh
+++ b/e2e-runner/e2e_runner/scripts/kubeadm-bootstrap.sh
@@ -46,7 +46,7 @@ run_cmd_with_retry() {
 
 update_k8s() {
     CI_PACKAGES=("kubectl" "kubelet" "kubeadm")
-    CI_IMAGES=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler" "conformance-amd64")
+    CI_IMAGES=("kube-apiserver" "kube-controller-manager" "kube-proxy" "kube-scheduler" "conformance")
 
     echo "Updating Kubernetes to version: $CI_VERSION"
 

--- a/e2e-runner/e2e_runner/utils.py
+++ b/e2e-runner/e2e_runner/utils.py
@@ -167,15 +167,31 @@ def run_remote_ssh_cmd(cmd, ssh_user, ssh_address, ssh_key_path=None,
 
 
 def rsync_upload(local_path, remote_path,
-                 ssh_user, ssh_address, ssh_key_path=None):
+                 ssh_user, ssh_address, ssh_key_path=None, delete=True):
     ssh_cmd = ("ssh -q "
                "-o StrictHostKeyChecking=no "
                "-o UserKnownHostsFile=/dev/null")
     if ssh_key_path:
         ssh_cmd += f" -i {ssh_key_path}"
-    run_shell_cmd([
-        "rsync", "-rlptD", "-e", f'"{ssh_cmd}"', "--delete",
-        local_path, f"{ssh_user}@{ssh_address}:{remote_path}"])
+    rsync_cmd = ["rsync", "-rlptD", "-e", f'"{ssh_cmd}"']
+    if delete:
+        rsync_cmd.append("--delete")
+    rsync_cmd.extend([local_path, f"{ssh_user}@{ssh_address}:{remote_path}"])
+    run_shell_cmd(rsync_cmd)
+
+
+def rsync_download(remote_path, local_path,
+                   ssh_user, ssh_address, ssh_key_path=None, delete=True):
+    ssh_cmd = ("ssh -q "
+               "-o StrictHostKeyChecking=no "
+               "-o UserKnownHostsFile=/dev/null")
+    if ssh_key_path:
+        ssh_cmd += f" -i {ssh_key_path}"
+    rsync_cmd = ["rsync", "-rlptD", "-e", f'"{ssh_cmd}"']
+    if delete:
+        rsync_cmd.append("--delete")
+    rsync_cmd.extend([f"{ssh_user}@{ssh_address}:{remote_path}", local_path])
+    run_shell_cmd(rsync_cmd)
 
 
 def make_tgz_archive(source_dir, output_file):

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -24,6 +24,7 @@ periodics:
         - --build=containerdbins
         - --build=containerdshim
         - --build=sdncnibins
+        - --retain-testing-env=True
         - capz_flannel
         - --flannel-mode=host-gw
         - --container-runtime=containerd
@@ -55,6 +56,7 @@ periodics:
         - --build=containerdbins
         - --build=containerdshim
         - --build=sdncnibins
+        - --retain-testing-env=True
         - capz_flannel
         - --flannel-mode=overlay
         - --container-runtime=containerd


### PR DESCRIPTION
* Download `kube-proxy.exe` build in the userdata script
* Build conformance tests image
* Add flag to retain testing envs
  * Also, retain only `master` jobs
* Use conformance image for E2E tests
* Update default `--parallel-test-nodes` param
    * Match the default value given to the `--win-agents-count` param
