### PR TITLE
Temporarily skip garbage collector tests

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -105,4 +105,4 @@ presets:
   - name: TEST_FOCUS_REGEX
     value: \\[Conformance\\]|\\[NodeConformance\\]|\\[sig-windows\\]|\\[sig-apps\\].CronJob|\\[sig-api-machinery\\].ResourceQuota|\\[sig-network\\].EndpointSlice
   - name: TEST_SKIP_REGEX
-    value: \\[LinuxOnly\\]|\\[Serial\\]|\\[Slow\\]|\\[alpha\\]|GMSA|\\[Feature\\:GPUDevicePlugin\\]
+    value: \\[LinuxOnly\\]|\\[Serial\\]|\\[Slow\\]|\\[alpha\\]|GMSA|\\[Feature\\:GPUDevicePlugin\\]|\\[sig-api-machinery\\].Garbage.collector


### PR DESCRIPTION
The intent is to re-enable the tests once https://github.com/kubernetes/kubernetes/issues/107394 is fixed.