### PR TITLE
CI Fixes

### DIFF
--- a/e2e-runner/e2e_runner/ci/capz_flannel/flannel/kube-flannel.yaml.j2
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/flannel/kube-flannel.yaml.j2
@@ -1,60 +1,9 @@
 ---
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: psp.flannel.unprivileged
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: docker/default
-    seccomp.security.alpha.kubernetes.io/defaultProfileName: docker/default
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
-    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
-spec:
-  privileged: false
-  volumes:
-  - configMap
-  - secret
-  - emptyDir
-  - hostPath
-  allowedHostPaths:
-  - pathPrefix: "/etc/cni/net.d"
-  - pathPrefix: "/etc/kube-flannel"
-  - pathPrefix: "/run/flannel"
-  readOnlyRootFilesystem: false
-  # Users and groups
-  runAsUser:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  fsGroup:
-    rule: RunAsAny
-  # Privilege Escalation
-  allowPrivilegeEscalation: false
-  defaultAllowPrivilegeEscalation: false
-  # Capabilities
-  allowedCapabilities: ['NET_ADMIN', 'NET_RAW']
-  defaultAddCapabilities: []
-  requiredDropCapabilities: []
-  # Host namespaces
-  hostPID: false
-  hostIPC: false
-  hostNetwork: true
-  hostPorts:
-  - min: 0
-    max: 65535
-  # SELinux
-  seLinux:
-    # SELinux is unused in CaaSP
-    rule: 'RunAsAny'
----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
 rules:
-- apiGroups: ['extensions']
-  resources: ['podsecuritypolicies']
-  verbs: ['use']
-  resourceNames: ['psp.flannel.unprivileged']
 - apiGroups:
   - ""
   resources:
@@ -221,7 +170,7 @@ spec:
             cpu: "100m"
             memory: "50Mi"
         securityContext:
-          privileged: false
+          privileged: true
           capabilities:
             add: ["NET_ADMIN", "NET_RAW"]
         env:

--- a/e2e-runner/e2e_runner/deployer/capz/capz.py
+++ b/e2e-runner/e2e_runner/deployer/capz/capz.py
@@ -776,7 +776,7 @@ class CAPZProvisioner(e2e_base.Deployer):
             cmd=[
                 "clusterctl", "init",
                 "--kubeconfig", self.mgmt_kubeconfig_path,
-                "--infrastructure", "azure",
+                "--infrastructure", "azure:v1.3.0",
                 "--wait-providers",
             ],
             env={

--- a/e2e-runner/e2e_runner/scripts/init-bootstrap-vm.sh
+++ b/e2e-runner/e2e_runner/scripts/init-bootstrap-vm.sh
@@ -3,7 +3,7 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-KIND_BIN_URL="https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-linux-amd64"
+KIND_BIN_URL="https://github.com/kubernetes-sigs/kind/releases/download/v0.13.0/kind-linux-amd64"
 
 function retrycmd_if_failure() {
   set +o errexit
@@ -68,7 +68,6 @@ nodes:
 - role: control-plane
   kubeadmConfigPatches:
   - |
-    apiVersion: kubeadm.k8s.io/v1beta2
     kind: ClusterConfiguration
     apiServer:
       certSANs:


### PR DESCRIPTION
* Bump kind version
* Run Flannel on Linux as a privileged pod
    * This is a workaround since `PodSecurityPolicy` was removed from the latest Kubernetes master branch (future v1.25 release).
* Pin cluster-api azure provider
 