### PR TITLE
Refactor CI buils & other updates

### DIFF
--- a/e2e-runner/e2e_runner/cli/run_ci.py
+++ b/e2e-runner/e2e_runner/cli/run_ci.py
@@ -59,7 +59,7 @@ class RunCI(Command):
             default="https://github.com/kubernetes/kubernetes")
         p.add_argument(
             "--k8s-branch",
-            default=e2e_constants.DEFAULT_KUBERNETES_VERSION)
+            default="master")
 
         p.add_argument(
             "--containerd-repo",

--- a/e2e-runner/e2e_runner/cli/run_ci.py
+++ b/e2e-runner/e2e_runner/cli/run_ci.py
@@ -26,6 +26,7 @@ class RunCI(Command):
             default=[],
             choices=[
                 "k8sbins", "containerdbins", "containerdshim", "sdncnibins",
+                "critools",
             ],
             help="Binaries to build.")
 

--- a/e2e-runner/e2e_runner/deployer/capz/capz.py
+++ b/e2e-runner/e2e_runner/deployer/capz/capz.py
@@ -114,27 +114,37 @@ class CAPZProvisioner(e2e_base.Deployer):
 
     @property
     def remote_k8s_path(self):
-        return os.path.join(self.remote_go_path, "src/k8s.io/kubernetes")
+        return os.path.join(
+            self.remote_go_path,
+            "src", "k8s.io", "kubernetes")
 
     @property
     def remote_containerd_path(self):
-        return os.path.join(self.remote_go_path,
-                            "src", "github.com", "containerd", "containerd")
+        return os.path.join(
+            self.remote_go_path,
+            "src", "github.com", "containerd", "containerd")
+
+    @property
+    def remote_containerd_shim_path(self):
+        return os.path.join(
+            self.remote_go_path,
+            "src", "github.com", "Microsoft", "hcsshim")
+
+    @property
+    def remote_cri_tools_path(self):
+        return os.path.join(
+            self.remote_go_path,
+            "src", "github.com", "kubernetes-sigs", "cri-tools")
+
+    @property
+    def remote_sdn_path(self):
+        return os.path.join(
+            self.remote_go_path,
+            "src", "github.com", "Microsoft", "windows-container-networking")
 
     @property
     def remote_artifacts_dir(self):
         return "~/www"
-
-    @property
-    def remote_sdn_path(self):
-        return os.path.join(self.remote_go_path,
-                            "src", "github.com",
-                            "Microsoft", "windows-container-networking")
-
-    @property
-    def remote_containerd_shim_path(self):
-        return os.path.join(self.remote_go_path,
-                            "src", "github.com", "Microsoft", "hcsshim")
 
     @property
     def bootstrap_vm_private_ip(self):

--- a/e2e-runner/e2e_runner/deployer/capz/control-plane.yaml.j2
+++ b/e2e-runner/e2e_runner/deployer/capz/control-plane.yaml.j2
@@ -112,7 +112,7 @@ spec:
       - /var/lib/etcddisk
     preKubeadmCommands:
     - curl -Lo /run/kubeadm/kubeadm-bootstrap.sh http://{{ bootstrap_vm_address }}/scripts/kubeadm-bootstrap.sh
-    - bash /run/kubeadm/kubeadm-bootstrap.sh --ci-packages-base-url http://{{ bootstrap_vm_address }} --ci-version {{ kubernetes_version }} --k8s-bins-built {{ k8s_bins }}
+    - bash /run/kubeadm/kubeadm-bootstrap.sh --ci-packages-base-url http://{{ bootstrap_vm_address }} --k8s-bins-built {{ k8s_bins }}
 {%- if flannel_mode == "overlay" %}
     postKubeadmCommands:
     - netplan apply

--- a/e2e-runner/e2e_runner/deployer/capz/windows-agents.yaml.j2
+++ b/e2e-runner/e2e_runner/deployer/capz/windows-agents.yaml.j2
@@ -13,9 +13,6 @@ spec:
     - type: Ready
       status: Unknown
       timeout: 5m
-    - type: Ready
-      status: "False"
-      timeout: 5m
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/e2e-runner/e2e_runner/deployer/capz/windows-agents.yaml.j2
+++ b/e2e-runner/e2e_runner/deployer/capz/windows-agents.yaml.j2
@@ -98,7 +98,7 @@ spec:
 {%- endraw %}
       preKubeadmCommands:
       - curl.exe -Lo /run/kubeadm/kubeadm-bootstrap.ps1 http://{{ bootstrap_vm_address }}/scripts/kubeadm-bootstrap.ps1
-      - powershell -C "/run/kubeadm/kubeadm-bootstrap.ps1 -CIPackagesBaseURL http://{{ bootstrap_vm_address }} -CIVersion {{ kubernetes_version }}{% if k8s_bins %} -K8sBins{% endif %}{% if sdn_cni_bins %} -SDNCNIBins{% endif %}{% if containerd_bins %} -ContainerdBins{% endif %}{% if containerd_shim_bins %} -ContainerdShimBins{% endif %}"
+      - powershell -C "/run/kubeadm/kubeadm-bootstrap.ps1 -CIPackagesBaseURL http://{{ bootstrap_vm_address }}{% if k8s_bins %} -K8sBins{% endif %}{% if containerd_bins %} -ContainerdBins{% endif %}{% if containerd_shim_bins %} -ContainerdShimBins{% endif %}{% if cri_tools_bins %} -CRIToolsBins{% endif %}{% if sdn_cni_bins %} -SDNCNIBins{% endif %}"
       users:
       - groups: Administrators
         name: capi

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -22,7 +22,6 @@ periodics:
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --build=k8sbins
         - --build=containerdbins
-        - --build=containerdshim
         - --build=sdncnibins
         - --retain-testing-env=True
         - capz_flannel
@@ -54,7 +53,6 @@ periodics:
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --build=k8sbins
         - --build=containerdbins
-        - --build=containerdshim
         - --build=sdncnibins
         - --retain-testing-env=True
         - capz_flannel

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -20,7 +20,6 @@ periodics:
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
-        - --k8s-branch=master
         - --build=k8sbins
         - --build=containerdbins
         - --build=containerdshim
@@ -53,7 +52,6 @@ periodics:
         - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
-        - --k8s-branch=master
         - --build=k8sbins
         - --build=containerdbins
         - --build=containerdshim


### PR DESCRIPTION
* Update `--k8s-branch` default value.
* Update MHC resource:
  * Remove `Ready: False` unhealthy condition.
* Refactor CI builds:
  * Add `cri-tools` CI build.
  * Build `cri-tools` and `containerd-shim-runhcs-v1` from the `containerd` source tree.
  * Backup binaries before update.
  * Cleanup the bootstrap VM artifacts directory.
* Don't build containerdshim separately for k8s `master` jobs:
  * Rely on the containerd shim bundled with containerd build via `containerdbins`.