### PR TITLE
Bump default K8s version & use new naming scheme for capz images

### DIFF
--- a/e2e-runner/Dockerfile
+++ b/e2e-runner/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 ARG CAPI_VERSION=v1.1.3
-ARG KUBECTL_VERSION=v1.23.6
+ARG KUBECTL_VERSION=v1.24.1
 
 # Install system APT packages & dependencies
 RUN apt-get update && \

--- a/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
@@ -358,7 +358,6 @@ class CapzFlannelCI(e2e_base.CI):
 
     def _add_kube_proxy_windows(self):
         context = {
-            "kubernetes_version": self.deployer.k8s_image_version,
             "container_runtime": self.opts.container_runtime,
             "win_os": self.opts.win_os,
             "container_image_tag": self.opts.container_image_tag,

--- a/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/windows/containerd/Dockerfile
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/windows/containerd/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE="mcr.microsoft.com/powershell:lts-nanoserver-1809"
-ARG K8S_VERSION="v1.23.6"
+ARG K8S_VERSION="v1.24.1"
 
 # Linux stage
 FROM --platform=linux/amd64 alpine:latest as prep

--- a/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/windows/docker/Dockerfile
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/windows/docker/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE="mcr.microsoft.com/powershell:lts-nanoserver-1809"
 ARG WINS_VERSION="v0.1.1"
 ARG YQ_VERSION="v4.20.2"
-ARG K8S_VERSION="v1.23.6"
+ARG K8S_VERSION="v1.24.1"
 
 # Linux stage
 FROM --platform=linux/amd64 alpine:latest as prep

--- a/e2e-runner/e2e_runner/constants.py
+++ b/e2e-runner/e2e_runner/constants.py
@@ -1,6 +1,6 @@
 AZURE_LOCATIONS = ["eastus2", "westeurope", "westus2", "southcentralus"]
 
-DEFAULT_KUBERNETES_VERSION = "v1.23.6"
+DEFAULT_KUBERNETES_VERSION = "v1.24.1"
 
 FLANNEL_MODE_OVERLAY = "overlay"
 FLANNEL_MODE_L2BRIDGE = "host-gw"

--- a/e2e-runner/e2e_runner/deployer/capz/control-plane.yaml.j2
+++ b/e2e-runner/e2e_runner/deployer/capz/control-plane.yaml.j2
@@ -147,7 +147,7 @@ spec:
 {%- endif %}
       image:
         marketplace:
-          publisher: cncf-upstream
-          offer: capi
-          sku: k8s-{{ image_sku_k8s_release }}-ubuntu-2004
-          version: latest
+          publisher: {{ capz_image_publisher }}
+          offer: {{ capz_image_ubuntu_offer }}
+          sku: {{ capz_image_ubuntu_sku }}
+          version: {{ capz_image_ubuntu_version }}

--- a/e2e-runner/e2e_runner/deployer/capz/windows-agents.yaml.j2
+++ b/e2e-runner/e2e_runner/deployer/capz/windows-agents.yaml.j2
@@ -63,10 +63,10 @@ spec:
 {%- endif %}
       image:
         marketplace:
-          publisher: cncf-upstream
-          offer: capi-windows
-          sku: {{ image_sku_windows }}
-          version: latest
+          publisher: {{ capz_image_publisher }}
+          offer: {{ capz_image_windows_offer }}
+          sku: {{ capz_image_windows_sku }}
+          version: {{ capz_image_windows_version }}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/e2e-runner/e2e_runner/scripts/kubeadm-bootstrap.ps1
+++ b/e2e-runner/e2e_runner/scripts/kubeadm-bootstrap.ps1
@@ -14,7 +14,7 @@ $global:BUILD_DIR = Join-Path $env:SystemDrive "build"
 $global:KUBERNETES_DIR = Join-Path $env:SystemDrive "k"
 $global:CONTAINERD_DIR = Join-Path $env:ProgramFiles "containerd"
 # https://github.com/kubernetes-sigs/cri-tools/releases
-$global:CRICTL_VERSION = "v1.23.0"
+$global:CRICTL_VERSION = "v1.24.1"
 
 
 function Start-ExecuteWithRetry {

--- a/prow/backup/Dockerfile
+++ b/prow/backup/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-ENV KUBECTL_VERSION=v1.23.6
+ENV KUBECTL_VERSION=v1.24.1
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install APT packages

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -191,11 +191,12 @@ periodics:
       command:
          - /workspace/entrypoint.sh
       args:
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.24
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.24.yaml
+        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
+        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Excluded\:WindowsDocker\]|Guestbook.application.should.create.and.stop.a.working.application
         - capz_flannel
+        - --kubernetes-version=v1.23.7
         - --flannel-mode=host-gw
         - --container-runtime=docker
         - --win-os=ltsc2019
@@ -218,11 +219,12 @@ periodics:
       command:
          - /workspace/entrypoint.sh
       args:
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.24
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.24.yaml
+        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
+        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Excluded\:WindowsDocker\]|Guestbook.application.should.create.and.stop.a.working.application
         - capz_flannel
+        - --kubernetes-version=v1.23.7
         - --flannel-mode=host-gw
         - --enable-win-dsr=False
         - --container-runtime=docker
@@ -246,11 +248,12 @@ periodics:
       command:
          - /workspace/entrypoint.sh
       args:
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.24
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.24.yaml
+        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
+        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Excluded\:WindowsDocker\]|Guestbook.application.should.create.and.stop.a.working.application
         - capz_flannel
+        - --kubernetes-version=v1.23.7
         - --flannel-mode=overlay
         - --container-runtime=docker
         - --win-os=ltsc2019
@@ -273,11 +276,12 @@ periodics:
       command:
          - /workspace/entrypoint.sh
       args:
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.24
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.24.yaml
+        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
+        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Excluded\:WindowsDocker\]|Guestbook.application.should.create.and.stop.a.working.application
         - capz_flannel
+        - --kubernetes-version=v1.23.7
         - --flannel-mode=overlay
         - --enable-win-dsr=False
         - --container-runtime=docker

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -78,8 +78,8 @@ periodics:
       command:
          - /workspace/entrypoint.sh
       args:
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
+        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.24
+        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.24.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --build=sdncnibins
@@ -106,8 +106,8 @@ periodics:
       command:
          - /workspace/entrypoint.sh
       args:
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
+        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.24
+        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.24.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --build=sdncnibins
@@ -134,8 +134,8 @@ periodics:
       command:
          - /workspace/entrypoint.sh
       args:
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
+        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.24
+        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.24.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --build=sdncnibins
@@ -163,8 +163,8 @@ periodics:
       command:
          - /workspace/entrypoint.sh
       args:
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
+        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.24
+        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.24.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|should.be.able.to.create.a.functioning.NodePort.service|should.be.able.to.change.the.type.from.ExternalName.to.NodePort
         - --build=sdncnibins
@@ -191,8 +191,8 @@ periodics:
       command:
          - /workspace/entrypoint.sh
       args:
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
+        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.24
+        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.24.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Excluded\:WindowsDocker\]|Guestbook.application.should.create.and.stop.a.working.application
         - capz_flannel
@@ -218,8 +218,8 @@ periodics:
       command:
          - /workspace/entrypoint.sh
       args:
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
+        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.24
+        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.24.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Excluded\:WindowsDocker\]|Guestbook.application.should.create.and.stop.a.working.application
         - capz_flannel
@@ -246,8 +246,8 @@ periodics:
       command:
          - /workspace/entrypoint.sh
       args:
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
+        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.24
+        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.24.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Excluded\:WindowsDocker\]|Guestbook.application.should.create.and.stop.a.working.application
         - capz_flannel
@@ -273,8 +273,8 @@ periodics:
       command:
          - /workspace/entrypoint.sh
       args:
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
+        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.24
+        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.24.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Excluded\:WindowsDocker\]|Guestbook.application.should.create.and.stop.a.working.application
         - capz_flannel


### PR DESCRIPTION
* Bump default K8s version to `v1.24.1`.
* Pin Docker jobs to K8s `v1.23.7`.
  * This is the last release to support `Dockershim`.
* Use new naming scheme for CAPZ images.