### PR TITLE
Add deployment retries & and use Ubuntu 22.04 for bootstrap VM

### DIFF
--- a/e2e-runner/e2e_runner/deployer/capz/capz.py
+++ b/e2e-runner/e2e_runner/deployer/capz/capz.py
@@ -523,8 +523,8 @@ class CAPZProvisioner(e2e_base.Deployer):
             storage_profile=compute_models.StorageProfile(
                 image_reference=compute_models.ImageReference(
                     publisher="Canonical",
-                    offer="0001-com-ubuntu-server-focal",
-                    sku="20_04-lts-gen2",
+                    offer="0001-com-ubuntu-server-jammy",
+                    sku="22_04-lts-gen2",
                     version="latest"
                 ),
                 os_disk=compute_models.OSDisk(

--- a/e2e-runner/e2e_runner/deployer/capz/control-plane.yaml.j2
+++ b/e2e-runner/e2e_runner/deployer/capz/control-plane.yaml.j2
@@ -1,19 +1,4 @@
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: MachineHealthCheck
-metadata:
-  name: {{ cluster_name }}-control-plane-mhc
-spec:
-  clusterName: {{ cluster_name }}
-  nodeStartupTimeout: 10m
-  selector:
-    matchLabels:
-      cluster.x-k8s.io/control-plane: ""
-  unhealthyConditions:
-    - type: Ready
-      status: Unknown
-      timeout: 5m
----
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
 metadata:

--- a/e2e-runner/e2e_runner/deployer/capz/windows-agents.yaml.j2
+++ b/e2e-runner/e2e_runner/deployer/capz/windows-agents.yaml.j2
@@ -1,20 +1,5 @@
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
-kind: MachineHealthCheck
-metadata:
-  name: {{ cluster_name }}-md-win-mhc
-spec:
-  clusterName: {{ cluster_name }}
-  nodeStartupTimeout: 20m
-  selector:
-    matchLabels:
-      cluster.x-k8s.io/deployment-name: {{ cluster_name }}-md-win
-  unhealthyConditions:
-    - type: Ready
-      status: Unknown
-      timeout: 5m
----
-apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   name: {{ cluster_name }}-md-win

--- a/e2e-runner/e2e_runner/scripts/init-bootstrap-vm.sh
+++ b/e2e-runner/e2e_runner/scripts/init-bootstrap-vm.sh
@@ -73,4 +73,3 @@ nodes:
       certSANs:
       - ${PUBLIC_IP}
 EOF
-kind create cluster --config /tmp/kind-config.yaml --wait 15m


### PR DESCRIPTION
* Add CAPZ deployment retries:
  * Retry deployments if CAPZ machines fail to provision.
  * Also, remove `MachineHealthCheck` resources, since they are not reliable.
* Use Ubuntu 22.04 LTS for bootstrap VM.