### PR TITLE
Revert bootstrap VM to 20.04 LTS SKU

### DIFF
--- a/e2e-runner/e2e_runner/deployer/capz/capz.py
+++ b/e2e-runner/e2e_runner/deployer/capz/capz.py
@@ -523,8 +523,8 @@ class CAPZProvisioner(e2e_base.Deployer):
             storage_profile=compute_models.StorageProfile(
                 image_reference=compute_models.ImageReference(
                     publisher="Canonical",
-                    offer="0001-com-ubuntu-server-jammy",
-                    sku="22_04-lts-gen2",
+                    offer="0001-com-ubuntu-server-focal",
+                    sku="20_04-lts-gen2",
                     version="latest"
                 ),
                 os_disk=compute_models.OSDisk(


### PR DESCRIPTION
Otherwise, the `master` jobs that build the kubelet on 22.04 LTS
will link a different glibc version than the one used by the
CAPZ Linux machines with 20.04 LTS.