### PR TITLE
Use least used Azure location for job runs

### DIFF
--- a/e2e-runner/e2e_runner/constants.py
+++ b/e2e-runner/e2e_runner/constants.py
@@ -4,10 +4,26 @@ AZURE_LOCATIONS = [
     "eastus",
     "eastus2",
     "northeurope",
+    "southcentralus",
     "uksouth",
     "westeurope",
     "westus2",
     "westus3"
+]
+
+COMPUTE_QUOTAS = [
+    "virtualMachines",
+    "cores",
+    "standardDSv3Family",
+    "PremiumDiskCount",
+]
+NETWORK_QUOTAS = [
+    "VirtualNetworks",
+    "NetworkInterfaces"
+    "NetworkSecurityGroups",
+    "LoadBalancers",
+    "PublicIPAddresses",
+    "RouteTables",
 ]
 
 DEFAULT_KUBERNETES_VERSION = "v1.24.1"

--- a/e2e-runner/e2e_runner/utils.py
+++ b/e2e-runner/e2e_runner/utils.py
@@ -181,3 +181,8 @@ def label_linux_nodes_no_schedule():
             kubectl, "label", "nodes", "--overwrite", node,
             "node-role.kubernetes.io/master=NoSchedule"
         ])
+
+
+def sort_dict_by_value(d):
+    return {k: v for k, v in
+            sorted(d.items(), key=lambda item: item[1])}


### PR DESCRIPTION
Instead of relying on `random.choice` for the Azure location selection,
we have an algorithm that determines the least used location.

This will fix some job failures related with quota limits.