### PR TITLE
Fix Docker jobs and bump cluster-api version

### DIFF
--- a/e2e-runner/Dockerfile
+++ b/e2e-runner/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-ARG CAPI_VERSION=v1.1.4
+ARG CAPI_VERSION=v1.1.5
 ARG KUBECTL_VERSION=v1.24.2
 
 # Install system APT packages & dependencies


### PR DESCRIPTION
* Fix Docker jobs:
  * Those jobs use a different Kubernetes version (since latest doesn't support Docker).
     Make sure that the DaemonSets use the appropriate `kube-proxy.exe` binary.
* Bump cluster-api version