### PR TITLE
CI Fixes

### DIFF
--- a/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
@@ -512,9 +512,12 @@ class CapzFlannelCI(e2e_base.CI):
         self.deployer.run_cmd_on_bootstrap_vm(
             cmd=[
                 "GOOS=windows make binaries",
-                ("GOOS=windows make -f Makefile.windows "
-                 "bin/containerd-shim-runhcs-v1.exe"),
-                ("GOOS=windows DESTDIR=$(pwd)/bin/cri-tools "
+                ("GOOS=windows "
+                 "make -f Makefile.windows bin/containerd-shim-runhcs-v1.exe"),
+                ("sudo "
+                 "GOOS=windows "
+                 "GOPATH=$HOME/go "
+                 "DESTDIR=$(pwd)/bin/cri-tools "
                  "./script/setup/install-critools"),
             ],
             cwd=remote_containerd_path)

--- a/e2e-runner/e2e_runner/cli/run_ci.py
+++ b/e2e-runner/e2e_runner/cli/run_ci.py
@@ -74,7 +74,7 @@ class RunCI(Command):
             default="https://github.com/microsoft/hcsshim")
         p.add_argument(
             "--containerd-shim-branch",
-            default="master")
+            default="main")
 
         p.add_argument(
             "--sdn-repo",

--- a/e2e-runner/e2e_runner/scripts/init-bootstrap-vm.sh
+++ b/e2e-runner/e2e_runner/scripts/init-bootstrap-vm.sh
@@ -33,10 +33,8 @@ GO_VERSION=$(cat /tmp/golang-version.txt)
 retrycmd_if_failure 5 10 5m curl -O https://dl.google.com/go/${GO_VERSION}.linux-amd64.tar.gz
 sudo tar -C /usr/local -xzf ${GO_VERSION}.linux-amd64.tar.gz
 rm ${GO_VERSION}.linux-amd64.tar.gz
-eval `cat /etc/environment`
-echo "PATH=\"$PATH:/usr/local/go/bin:$HOME/go/bin\"" | sudo tee /etc/environment
-echo "GOPATH=\"$HOME/go\"" | sudo tee -a /etc/environment
-/usr/local/go/bin/go version
+sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
+go version
 
 retrycmd_if_failure 5 10 5m sudo apt-get install -y ca-certificates curl gnupg lsb-release
 sudo mkdir -p /etc/apt/keyrings


### PR DESCRIPTION
* Update default branch for `microsoft/hcsshim` repository.
* Symlink the `go` bin to `/usr/local/bin/go` instead of parsing the
  `/etc/environment` to append the bin dir from the go
  installation directory.
* Use `sudo` when running the `./script/setup/install-critools` script
  from containerd. This is needed because the script itself uses sudo,
  and we would end up with permissions issues if we don't do this.