### PR TITLE
Revert `Apply Prow CronJobs` GitHub action task

### DIFF
--- a/.github/workflows/prow-cronjobs.yaml
+++ b/.github/workflows/prow-cronjobs.yaml
@@ -25,8 +25,8 @@ jobs:
       - name: Apply Prow CronJobs
         run: |
           set -e
-          echo $KUBECONFIG_YAML > /tmp/kubeconfig.yaml
-          export KUBECONFIG=/tmp/kubeconfig.yaml
+          echo $KUBECONFIG_JSON > /tmp/kubeconfig.json
+          export KUBECONFIG=/tmp/kubeconfig.json
           kubectl apply -f ./prow/cronjobs
         env:
-          KUBECONFIG_YAML: ${{ secrets.KUBECONFIG_YAML }}
+          KUBECONFIG_JSON: ${{ secrets.KUBECONFIG_JSON }}


### PR DESCRIPTION
Revert to using `KUBECONFIG_JSON`.