### PR TITLE
Download K8s version for LTSC2019 jobs

### DIFF
--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -23,6 +23,7 @@ periodics:
         - --build=containerdbins
         - --build=sdncnibins
         - capz_flannel
+        - --kubernetes-version=v1.25.2
         - --flannel-mode=host-gw
         - --container-runtime=containerd
         - --win-os=ltsc2019
@@ -52,6 +53,7 @@ periodics:
         - --build=containerdbins
         - --build=sdncnibins
         - capz_flannel
+        - --kubernetes-version=v1.25.2
         - --flannel-mode=overlay
         - --container-runtime=containerd
         - --win-os=ltsc2019
@@ -79,6 +81,7 @@ periodics:
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --build=sdncnibins
         - capz_flannel
+        - --kubernetes-version=v1.25.2
         - --flannel-mode=host-gw
         - --container-runtime=containerd
         - --win-os=ltsc2019
@@ -106,6 +109,7 @@ periodics:
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --build=sdncnibins
         - capz_flannel
+        - --kubernetes-version=v1.25.2
         - --flannel-mode=overlay
         - --container-runtime=containerd
         - --win-os=ltsc2019


### PR DESCRIPTION
The LTSC2019 CAPZ machines are not properly deployed with
the `v1.25.3` Azure image.

This change will be reverted once the upstream images are fixed.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>