### PR TITLE
Set AKS node_resource_group

### DIFF
--- a/e2e-runner/e2e_runner/ci/aks/aks.py
+++ b/e2e-runner/e2e_runner/ci/aks/aks.py
@@ -111,6 +111,7 @@ class AksCI(e2e_base.CI):
         return aks_models.ManagedCluster(
             location=self.location,
             kubernetes_version=self.aks_version,
+            node_resource_group=f"{self.aks_name}-node-rg",
             dns_prefix=self.aks_name,
             enable_rbac=True,
             agent_pool_profiles=[


### PR DESCRIPTION
Without this, the default node RG exceeds maximum Azure RG name limit.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>