### PR TITLE
Set fixed containerd version for main builds

### DIFF
--- a/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
@@ -902,7 +902,7 @@ class CapzFlannelCI(e2e_base.CI):
         self.logging.info("Building containerd binaries")
         self.bootstrap_vm.exec(
             script=[
-                "GOOS=windows make binaries",
+                "VERSION=1.7.0+unknown GOOS=windows make binaries",  # noqa: TODO(ibalutoiu): This hard-coded version needs to be removed once containerd v1.7.0 gets released.
                 "GOOS=windows make -f Makefile.windows bin/containerd-shim-runhcs-v1.exe",  # noqa:
                 "sudo GOOS=windows GOPATH=$HOME/go DESTDIR=$(pwd)/bin/cri-tools ./script/setup/install-critools",  # noqa:
             ],


### PR DESCRIPTION
This change re-applies PR https://github.com/e2e-win/k8s-e2e-runner/pull/157, which was removed recently.
Until a stable containerd is released, we still need it.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>