### PR TITLE
Add Aks+AzureCNI 1.25 release testing and other updates

### DIFF
--- a/e2e-runner/e2e_runner/base.py
+++ b/e2e-runner/e2e_runner/base.py
@@ -3,7 +3,6 @@ import os
 
 import tenacity
 import yaml
-
 from e2e_runner import constants as e2e_constants
 from e2e_runner import exceptions as e2e_exceptions
 from e2e_runner import logger as e2e_logger
@@ -129,6 +128,8 @@ class CI(object):
             'ginkgo_flags': ginkgo_flags,
             'e2e_flags': e2e_flags,
         }
+        if self.opts.e2e_bin:
+            ctxt["e2e_bin_url"] = self.opts.e2e_bin
         output_file = "/tmp/conformance.yaml"
         e2e_utils.render_template("templates/conformance.yaml.j2", output_file,
                                   ctxt, self.e2e_runner_dir)

--- a/e2e-runner/e2e_runner/cli/run_ci.py
+++ b/e2e-runner/e2e_runner/cli/run_ci.py
@@ -44,6 +44,10 @@ class RunCI(Command):
             help="Download link for the manifest file used to pre-pull the "
                  "container images on the nodes.")
         p.add_argument(
+            "--e2e-bin",
+            default=None,
+            help="URL with the Kubernetes E2E tests binary.")
+        p.add_argument(
             "--test-focus-regex",
             default="\\[Conformance\\]|\\[NodeConformance\\]|\\[sig-windows\\]")  # noqa
         p.add_argument(

--- a/e2e-runner/e2e_runner/cli/run_ci.py
+++ b/e2e-runner/e2e_runner/cli/run_ci.py
@@ -36,7 +36,7 @@ class RunCI(Command):
             default=4)
         p.add_argument(
             "--repo-list",
-            default="https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list",  # noqa
+            default="https://capzwin.blob.core.windows.net/images/image-repo-list",  # noqa
             help="Repo list with registries for test images.")
         p.add_argument(
             "--e2e-bin",

--- a/e2e-runner/e2e_runner/cli/run_ci.py
+++ b/e2e-runner/e2e_runner/cli/run_ci.py
@@ -39,11 +39,6 @@ class RunCI(Command):
             default="https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/images/image-repo-list",  # noqa
             help="Repo list with registries for test images.")
         p.add_argument(
-            "--prepull-yaml",
-            default="https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/gce/prepull.yaml",  # noqa
-            help="Download link for the manifest file used to pre-pull the "
-                 "container images on the nodes.")
-        p.add_argument(
             "--e2e-bin",
             default=None,
             help="URL with the Kubernetes E2E tests binary.")

--- a/e2e-runner/e2e_runner/templates/conformance.yaml.j2
+++ b/e2e-runner/e2e_runner/templates/conformance.yaml.j2
@@ -50,6 +50,21 @@ kind: Pod
 metadata:
   name: conformance-tests
 spec:
+{%- if e2e_bin_url is defined %}
+  initContainers:
+  - name: init-conformance
+    image: curlimages/curl:latest
+    securityContext:
+      runAsUser: 0
+    command:
+    - sh
+    args:
+    - -exc
+    - "curl -L -o /conformance/e2e.test {{ e2e_bin_url }} && chmod +x /conformance/e2e.test"
+    volumeMounts:
+    - name: conformance-storage
+      mountPath: /conformance
+{%- endif %}
   containers:
   - name: conformance-tests
     image: {{ conformance_image }}
@@ -67,13 +82,21 @@ spec:
       mountPath: /docker-creds
       readOnly: true
 {%- endif %}
+{%- if e2e_bin_url is defined %}
+    - name: conformance-storage
+      mountPath: /conformance
+{%- endif %}
     command:
     - /usr/local/bin/ginkgo
     args:
 {%- for key, value in ginkgo_flags.items() %}
     - --{{ key }}={{ value }}
 {%- endfor %}
+{%- if e2e_bin_url is defined %}
+    - /conformance/e2e.test
+{%- else %}
     - /usr/local/bin/e2e.test
+{%- endif %}
     - --
 {%- for key, value in e2e_flags.items() %}
     - --{{ key }}={{ value }}
@@ -89,6 +112,11 @@ spec:
   - name: docker-creds
     secret:
       secretName: docker-creds
+{%- endif %}
+{%- if e2e_bin_url is defined %}
+  - name: conformance-storage
+    hostPath:
+      path: /tmp/conformance-storage
 {%- endif %}
   restartPolicy: Never
   serviceAccountName: k8s-admin

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -16,7 +16,6 @@ periodics:
          - /workspace/entrypoint.sh
       args:
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-master
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --build=k8sbins
@@ -46,7 +45,6 @@ periodics:
          - /workspace/entrypoint.sh
       args:
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-master
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-master.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --build=k8sbins
@@ -76,7 +74,6 @@ periodics:
          - /workspace/entrypoint.sh
       args:
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.25
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.25.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --build=sdncnibins
@@ -104,7 +101,6 @@ periodics:
          - /workspace/entrypoint.sh
       args:
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.25
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.25.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --build=sdncnibins
@@ -132,7 +128,6 @@ periodics:
          - /workspace/entrypoint.sh
       args:
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.25
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.25.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --build=sdncnibins
@@ -159,7 +154,6 @@ periodics:
          - /workspace/entrypoint.sh
       args:
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.25
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.25.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --build=sdncnibins
@@ -185,7 +179,6 @@ periodics:
          - /workspace/entrypoint.sh
       args:
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.24
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.24.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - aks
@@ -208,7 +201,6 @@ periodics:
          - /workspace/entrypoint.sh
       args:
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.24
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.24.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - aks
@@ -232,7 +224,6 @@ periodics:
          - /workspace/entrypoint.sh
       args:
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Excluded\:WindowsDocker\]|Guestbook.application.should.create.and.stop.a.working.application
         - capz_flannel
@@ -259,7 +250,6 @@ periodics:
          - /workspace/entrypoint.sh
       args:
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Excluded\:WindowsDocker\]|Guestbook.application.should.create.and.stop.a.working.application
         - capz_flannel
@@ -287,7 +277,6 @@ periodics:
          - /workspace/entrypoint.sh
       args:
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Excluded\:WindowsDocker\]|Guestbook.application.should.create.and.stop.a.working.application
         - capz_flannel
@@ -314,7 +303,6 @@ periodics:
          - /workspace/entrypoint.sh
       args:
         - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.23
-        - --prepull-yaml=https://capzwin.blob.core.windows.net/images/prepull-release-1.23.yaml
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Excluded\:WindowsDocker\]|Guestbook.application.should.create.and.stop.a.working.application
         - capz_flannel

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -157,7 +157,7 @@ periodics:
         - --win-os=ltsc2022
         - --cluster-name=capzctrd-ltsc2022-$(BUILD_ID)
 
-- name: aks-e2e-ltsc2019-azurecni
+- name: aks-e2e-ltsc2019-azurecni-1.24
   cron: "0 2 * * *"
   always_run: true
   labels:
@@ -175,10 +175,11 @@ periodics:
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - aks
+        - --aks-version=1.24.6
         - --win-agents-sku=Windows2019
         - --cluster-name=aks-e2e-ltsc2019-$(BUILD_ID)
 
-- name: aks-e2e-ltsc2022-azurecni
+- name: aks-e2e-ltsc2022-azurecni-1.24
   cron: "0 8 * * *"
   always_run: true
   labels:
@@ -196,6 +197,7 @@ periodics:
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - aks
+        - --aks-version=1.24.6
         - --win-agents-sku=Windows2022
         - --cluster-name=aks-e2e-ltsc2022-$(BUILD_ID)
 

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -201,6 +201,50 @@ periodics:
         - --win-agents-sku=Windows2022
         - --cluster-name=aks-e2e-ltsc2022-$(BUILD_ID)
 
+- name: aks-e2e-ltsc2019-azurecni-1.25
+  cron: "0 4 * * *"
+  always_run: true
+  labels:
+    preset-test-regex: "true"
+    preset-ssh-key: "true"
+    preset-prod-azure-account: "true"
+    preset-windows-private-registry-cred: "true"
+  spec:
+    containers:
+    - image: ghcr.io/e2e-win/k8s-e2e-runner:main
+      imagePullPolicy: Always
+      command:
+         - /workspace/entrypoint.sh
+      args:
+        - --test-focus-regex=$(TEST_FOCUS_REGEX)
+        - --test-skip-regex=$(TEST_SKIP_REGEX)
+        - aks
+        - --aks-version=1.25.2
+        - --win-agents-sku=Windows2019
+        - --cluster-name=aks-e2e-ltsc2019-$(BUILD_ID)
+
+- name: aks-e2e-ltsc2022-azurecni-1.25
+  cron: "0 10 * * *"
+  always_run: true
+  labels:
+    preset-test-regex: "true"
+    preset-ssh-key: "true"
+    preset-prod-azure-account: "true"
+    preset-windows-private-registry-cred: "true"
+  spec:
+    containers:
+    - image: ghcr.io/e2e-win/k8s-e2e-runner:main
+      imagePullPolicy: Always
+      command:
+         - /workspace/entrypoint.sh
+      args:
+        - --test-focus-regex=$(TEST_FOCUS_REGEX)
+        - --test-skip-regex=$(TEST_SKIP_REGEX)
+        - aks
+        - --aks-version=1.25.2
+        - --win-agents-sku=Windows2022
+        - --cluster-name=aks-e2e-ltsc2022-$(BUILD_ID)
+
 - name: k8s-e2e-ltsc2019-docker-flannel-winbridge-stable
   cron: "0 9 * * *"
   always_run: true

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -15,7 +15,6 @@ periodics:
       command:
          - /workspace/entrypoint.sh
       args:
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-master
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --build=k8sbins
@@ -44,7 +43,6 @@ periodics:
       command:
          - /workspace/entrypoint.sh
       args:
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-master
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --build=k8sbins
@@ -73,7 +71,6 @@ periodics:
       command:
          - /workspace/entrypoint.sh
       args:
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.25
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --build=sdncnibins
@@ -100,7 +97,6 @@ periodics:
       command:
          - /workspace/entrypoint.sh
       args:
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.25
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --build=sdncnibins
@@ -127,7 +123,6 @@ periodics:
       command:
          - /workspace/entrypoint.sh
       args:
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.25
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --build=sdncnibins
@@ -153,7 +148,6 @@ periodics:
       command:
          - /workspace/entrypoint.sh
       args:
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.25
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --build=sdncnibins
@@ -178,7 +172,6 @@ periodics:
       command:
          - /workspace/entrypoint.sh
       args:
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.24
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - aks
@@ -200,7 +193,6 @@ periodics:
       command:
          - /workspace/entrypoint.sh
       args:
-        - --repo-list=https://capzwin.blob.core.windows.net/images/image-repo-list-release-1.24
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - aks


### PR DESCRIPTION
* Add option for pre-built K8s e2e tests binary.
* Remove --prepull-yaml option.
  * Rely on the flag `prepull-images` from K8s E2E binary to cache the images before the tests.
* Unify common repo-list files.
* Reuse existing AKS+AzureCNI jobs for `1.24` release testing.
* Add AKS+AzureCNI jobs for `1.25` release testing.