### PR TITLE
Add option to install private binaries & use them for AKS 1.24 + WS 2019

### DIFF
--- a/e2e-runner/e2e_runner/ci/aks/aks.py
+++ b/e2e-runner/e2e_runner/ci/aks/aks.py
@@ -9,6 +9,7 @@ from azure.mgmt.containerservice import ContainerServiceClient
 from azure.mgmt.network import NetworkManagementClient
 from azure.mgmt.resource import ResourceManagementClient
 from e2e_runner import base as e2e_base
+from e2e_runner import exceptions as e2e_exceptions
 from e2e_runner import logger as e2e_logger
 from e2e_runner.utils import azure as e2e_azure_utils
 from e2e_runner.utils import utils as e2e_utils
@@ -33,6 +34,7 @@ class AksCI(e2e_base.CI):
         self.win_agents_count = self.opts.win_agents_count
         self.win_agents_size = self.opts.win_agents_size
         self.win_agents_sku = self.opts.win_agents_sku
+        self.win_private_bins_zip_url = self.opts.win_private_bins_zip_url
         self.ssh_public_key = e2e_utils.get_file_content(
             os.environ["SSH_PUBLIC_KEY_PATH"])
 
@@ -46,12 +48,22 @@ class AksCI(e2e_base.CI):
 
         self.location = self._get_location()
 
+    @property
+    def windows_private_addresses(self):
+        addresses = e2e_utils.get_k8s_agents_private_addresses("windows")
+        if len(addresses) != self.win_agents_count:
+            raise e2e_exceptions.KubernetesNodeNotFound(
+                f"Expected {self.win_agents_count} Windows agents "
+                f"addresses, but found only {len(addresses)}")
+        return addresses
+
     def up(self):
         start = time.time()
         self._setup_aks_cluster()
         self._setup_aks_kubeconfig()
         self.logging.info("The cluster provisioned in %.2f minutes",
                           (time.time() - start) / 60)
+        self._apply_proxy_terminating_endpoints_windows_patch()
 
     def down(self):
         self.logging.info("Deleting AKS cluster resource group")
@@ -182,3 +194,77 @@ class AksCI(e2e_base.CI):
             taint.split("=")[0] for taint in self._get_linux_agents_taints()
         ]
         return linux_agents_taints
+
+    def _apply_proxy_terminating_endpoints_windows_patch(self):
+        if not self.win_private_bins_zip_url:
+            self.logging.info(
+                "The CI option '--win-private-bins-zip-url' was not "
+                "specified. Skipping Windows agents patching.")
+            return
+
+        self._setup_jumpbox()
+
+        dir_name = "proxy_terminating_endpoints"
+        e2e_utils.download_file(
+            self.win_private_bins_zip_url, f"/tmp/{dir_name}.zip")
+        e2e_utils.upload_to_pod(
+            self.JUMPBOX_POD, f"/tmp/{dir_name}.zip", f"/tmp/{dir_name}.zip")
+
+        for address in self.windows_private_addresses:
+            self.logging.info("Patching K8s Windows agent: %s", address)
+            ssh_kwargs = {
+                "user": "azureuser",
+                "address": address,
+            }
+
+            # upload zip archive with the private bins, and extract it
+            self._jumpbox_exec_scp(
+                file_path=f"/tmp/{dir_name}.zip",
+                remote_file_path=f"/{dir_name}.zip",
+                **ssh_kwargs,
+            )
+            self._jumpbox_exec_ssh(
+                cmd=["powershell", "mkdir", "-force", f"/{dir_name}"],
+                **ssh_kwargs,
+            )
+            self._jumpbox_exec_ssh(
+                cmd=["tar", "xzf", f"/{dir_name}.zip", "-C", f"/{dir_name}"],
+                **ssh_kwargs,
+            )
+
+            # replace kube-proxy binary
+            self._jumpbox_exec_ssh(
+                cmd=["/k/nssm", "stop", "kubeproxy"],
+                **ssh_kwargs,
+            )
+            self._jumpbox_exec_ssh(
+                cmd=["powershell", "cp", "-force", f"/{dir_name}/kube-proxy.exe", "/k/kube-proxy.exe"],  # noqa:
+                **ssh_kwargs,
+            )
+
+            # install the HNS private binaries
+            self._jumpbox_exec_ssh(
+                cmd=["bcdedit", "/set", "testsigning", "on"],
+                **ssh_kwargs,
+            )
+            hns_binaries_map = {
+                "HostNetSvc.dll": "/Windows/System32/HostNetSvc.dll",
+                "vfpapi.dll": "/Windows/System32/vfpapi.dll",
+                "vfpctrl.exe": "/Windows/System32/vfpctrl.exe",
+                "vfpext.sys": "/Windows/System32/drivers/vfpext.sys",
+            }
+            for file_name in hns_binaries_map:
+                self._jumpbox_exec_ssh(
+                    cmd=[
+                        f"/{dir_name}/sfpcopy.exe",
+                        f"/{dir_name}/{file_name}",
+                        hns_binaries_map[file_name],
+                    ],
+                    **ssh_kwargs,
+                )
+            self._jumpbox_exec_ssh(
+                cmd=["shutdown", "/r", "/t", "0"],
+                **ssh_kwargs,
+            )
+
+        self._remove_jumpbox()

--- a/e2e-runner/e2e_runner/cli/run_ci.py
+++ b/e2e-runner/e2e_runner/cli/run_ci.py
@@ -54,6 +54,12 @@ class RunCI(Command):
             default=False,
             help="Retain the testing environment, if the conformance tests "
                  "failed. Useful for debugging purposes.")
+        p.add_argument(
+            "--win-private-bins-zip-url",
+            type=str,
+            help="URL of the zip archive with the private binaries to be "
+                 "installed on the Kubernetes Windows agents before running "
+                 "the E2E tests.")
 
         p.add_argument(
             "--k8s-repo",

--- a/e2e-runner/e2e_runner/exceptions.py
+++ b/e2e-runner/e2e_runner/exceptions.py
@@ -26,6 +26,10 @@ class KubernetesEndpointNotFound(Exception):
     pass
 
 
+class KubernetesNodeNotFound(Exception):
+    pass
+
+
 class InvalidKubernetesEndpoint(Exception):
     pass
 

--- a/e2e-runner/e2e_runner/templates/jumpbox.yaml
+++ b/e2e-runner/e2e_runner/templates/jumpbox.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: jumpbox
+spec:
+  containers:
+  - name: alpine
+    image: alpine:latest
+    command:
+    - sleep
+    args:
+    - infinity
+  priorityClassName: system-node-critical
+  tolerations:
+  - operator: Exists
+    effect: NoSchedule
+  nodeSelector:
+    kubernetes.io/os: linux

--- a/e2e-runner/e2e_runner/utils/kubernetes.py
+++ b/e2e-runner/e2e_runner/utils/kubernetes.py
@@ -6,7 +6,6 @@ import time
 import pendulum
 import tenacity
 from e2e_runner import logger as e2e_logger
-
 from kubernetes import client, config, utils, watch
 
 logging = e2e_logger.get_logger(__name__)
@@ -111,6 +110,9 @@ class KubernetesClient(object):
     def wait_running_pod(self, name, namespace="default", timeout=300):
         self.wait_pod_phase(
             name, "Running", namespace=namespace, timeout=timeout)
+
+    def delete_pod(self, name, namespace="default"):
+        self.core_v1_api.delete_namespaced_pod(name=name, namespace=namespace)
 
     def create_configmap(self, name, data, namespace="default"):
         config_map = client.V1ConfigMap()

--- a/e2e-runner/e2e_runner/utils/utils.py
+++ b/e2e-runner/e2e_runner/utils/utils.py
@@ -200,6 +200,22 @@ def exec_kubectl(args, env=None, timeout=(3 * 3600),
             return stdout, stderr
 
 
+def get_k8s_agents_private_addresses(operating_system):
+    private_addresses, _ = exec_kubectl(
+        args=[
+            "get", "nodes",  # pyright: ignore
+            "-o", "jsonpath=\"{{.items[?(@.status.nodeInfo.operatingSystem == '{}')].status.addresses[?(@.type == 'InternalIP')].address}}\"".format(operating_system),  # pyright: ignore # noqa:
+        ],
+        capture_output=True,
+        hide_cmd=True,
+    )
+    return private_addresses.strip().split()  # pyright: ignore
+
+
+def exec_pod(pod_name, cmd):
+    exec_kubectl(["exec", pod_name, "--", *cmd])
+
+
 def upload_to_pod(pod_name, local_path, remote_path):
     exec_kubectl(["cp", local_path, f"{pod_name}:{remote_path}"])
 

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -174,6 +174,7 @@ periodics:
       args:
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
+        - --win-private-bins-zip-url=http://10.244.0.235/proxy_terminating_endpoints.zip
         - aks
         - --aks-version=1.24.6
         - --win-agents-sku=Windows2019


### PR DESCRIPTION
* Add option to install private binaries:
  * The private bins should be given as a URL to a zip archive, which
     should contain everything necessary to be installed
* Use private binaries for AKS 1.24 + WS 2019 job:
  * Install the private binaries required to enable proxy terminating
     endpoints feature gate on WS 2019 with AKS 1.24.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>