### PR TITLE
Update AKS 1.25 version

### DIFF
--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -240,7 +240,7 @@ periodics:
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]
         - aks
-        - --aks-version=1.25.2
+        - --aks-version=1.25.4
         - --win-agents-sku=Windows2019
         - --cluster-name=aks-e2e-ltsc2019-$(BUILD_ID)
 
@@ -262,7 +262,7 @@ periodics:
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]
         - aks
-        - --aks-version=1.25.2
+        - --aks-version=1.25.4
         - --win-agents-sku=Windows2022
         - --cluster-name=aks-e2e-ltsc2022-$(BUILD_ID)
 


### PR DESCRIPTION
Version 1.25.2 is not supported anymore in some of the Azure regions.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>