### PR TITLE
Add AKS 1.26 + AzureCNI testing and conformance tests updates

### DIFF
--- a/e2e-runner/e2e_runner/base.py
+++ b/e2e-runner/e2e_runner/base.py
@@ -126,11 +126,13 @@ class CI(object):
         else:
             ginkgoFlags["progress"] = "true"
             if self.kubernetes_version >= "v1.25":
-                ginkgoFlags["no-color"] = "true"
                 ginkgoFlags["slow-spec-threshold"] = "5m"
             else:
-                ginkgoFlags["noColor"] = "true"
                 ginkgoFlags["slowSpecThreshold"] = "300.0"
+        if self.kubernetes_version >= "v1.25":
+            ginkgoFlags["no-color"] = "true"
+        else:
+            ginkgoFlags["noColor"] = "true"
 
         e2eFlags = {
             "provider": "skeleton",

--- a/e2e-runner/e2e_runner/cli/run_ci.py
+++ b/e2e-runner/e2e_runner/cli/run_ci.py
@@ -39,6 +39,9 @@ class RunCI(Command):
             default="https://capzwin.blob.core.windows.net/images/image-repo-list",  # noqa
             help="Repo list with registries for test images.")
         p.add_argument(
+            "--conformance-image",
+            help="Conformance test image to use for the E2E tests.")
+        p.add_argument(
             "--e2e-bin",
             default=None,
             help="URL with the Kubernetes E2E tests binary.")

--- a/e2e-runner/e2e_runner/exceptions.py
+++ b/e2e-runner/e2e_runner/exceptions.py
@@ -46,5 +46,9 @@ class InvalidOperatingSystem(Exception):
     pass
 
 
+class InvalidConformanceImageTag(Exception):
+    pass
+
+
 class VersionMismatch(Exception):
     pass

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -12,8 +12,6 @@ periodics:
     containers:
     - image: ghcr.io/e2e-win/k8s-e2e-runner:main
       imagePullPolicy: Always
-      command:
-         - /workspace/entrypoint.sh
       args:
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]
@@ -38,8 +36,6 @@ periodics:
     containers:
     - image: ghcr.io/e2e-win/k8s-e2e-runner:main
       imagePullPolicy: Always
-      command:
-         - /workspace/entrypoint.sh
       args:
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]
@@ -64,8 +60,6 @@ periodics:
     containers:
     - image: ghcr.io/e2e-win/k8s-e2e-runner:main
       imagePullPolicy: Always
-      command:
-         - /workspace/entrypoint.sh
       args:
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]
@@ -88,8 +82,6 @@ periodics:
     containers:
     - image: ghcr.io/e2e-win/k8s-e2e-runner:main
       imagePullPolicy: Always
-      command:
-         - /workspace/entrypoint.sh
       args:
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]
@@ -112,8 +104,6 @@ periodics:
     containers:
     - image: ghcr.io/e2e-win/k8s-e2e-runner:main
       imagePullPolicy: Always
-      command:
-         - /workspace/entrypoint.sh
       args:
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]
@@ -136,8 +126,6 @@ periodics:
     containers:
     - image: ghcr.io/e2e-win/k8s-e2e-runner:main
       imagePullPolicy: Always
-      command:
-         - /workspace/entrypoint.sh
       args:
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]
@@ -159,8 +147,6 @@ periodics:
     containers:
     - image: ghcr.io/e2e-win/k8s-e2e-runner:main
       imagePullPolicy: Always
-      command:
-         - /workspace/entrypoint.sh
       args:
         - --test-focus-regex=$(TEST_FOCUS_REGEX)|\[sig-network\].LoadBalancers
         - --test-skip-regex=$(TEST_SKIP_REGEX)
@@ -183,8 +169,6 @@ periodics:
     containers:
     - image: ghcr.io/e2e-win/k8s-e2e-runner:main
       imagePullPolicy: Always
-      command:
-         - /workspace/entrypoint.sh
       args:
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]
@@ -205,8 +189,6 @@ periodics:
     containers:
     - image: ghcr.io/e2e-win/k8s-e2e-runner:main
       imagePullPolicy: Always
-      command:
-         - /workspace/entrypoint.sh
       args:
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]
@@ -227,8 +209,6 @@ periodics:
     containers:
     - image: ghcr.io/e2e-win/k8s-e2e-runner:main
       imagePullPolicy: Always
-      command:
-         - /workspace/entrypoint.sh
       args:
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -236,3 +236,43 @@ periodics:
         - --aks-version=1.25
         - --win-agents-sku=Windows2022
         - --cluster-name=aks-e2e-ltsc2022-$(BUILD_ID)
+
+- name: aks-e2e-ltsc2019-azurecni-1.26
+  cron: "0 9 * * *"
+  always_run: true
+  labels:
+    preset-test-regex: "true"
+    preset-ssh-key: "true"
+    preset-prod-azure-account: "true"
+    preset-windows-private-registry-cred: "true"
+  spec:
+    containers:
+    - image: ghcr.io/e2e-win/k8s-e2e-runner:main
+      imagePullPolicy: Always
+      args:
+        - --test-focus-regex=$(TEST_FOCUS_REGEX)
+        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]
+        - aks
+        - --aks-version=1.26
+        - --win-agents-sku=Windows2019
+        - --cluster-name=aks-e2e-ltsc2019-$(BUILD_ID)
+
+- name: aks-e2e-ltsc2022-azurecni-1.26
+  cron: "0 15 * * *"
+  always_run: true
+  labels:
+    preset-test-regex: "true"
+    preset-ssh-key: "true"
+    preset-prod-azure-account: "true"
+    preset-windows-private-registry-cred: "true"
+  spec:
+    containers:
+    - image: ghcr.io/e2e-win/k8s-e2e-runner:main
+      imagePullPolicy: Always
+      args:
+        - --test-focus-regex=$(TEST_FOCUS_REGEX)
+        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]
+        - aks
+        - --aks-version=1.26
+        - --win-agents-sku=Windows2022
+        - --cluster-name=aks-e2e-ltsc2022-$(BUILD_ID)


### PR DESCRIPTION
* Fix no-color ginkgo flag, This didn't appear for conformance images >= `v1.27`
* Add `--conformance-image` option. Allow customization of the conformance image to be used when running E2E tests.
* Remove explicit entrypoint override. This is not needed, since that's the default Docker image entrypoint.
* Add AKS 1.26 with AzureCNI testing.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>