### PR TITLE
Get the pod logs when tests finish

### DIFF
--- a/e2e-runner/e2e_runner/utils/utils.py
+++ b/e2e-runner/e2e_runner/utils/utils.py
@@ -251,6 +251,14 @@ def kubectl_watch_logs(k8s_client, pod_name, namespace="default",
         time.sleep(1)
 
 
+def get_pod_logs(pod_name, namespace="default", container_name=None):
+    args = ["logs", "--namespace", namespace]
+    if container_name:
+        args += ["--container", container_name]
+    args += [pod_name]
+    _, _ = exec_kubectl(args)
+
+
 def get_k8s_agents_private_addresses(operating_system):
     private_addresses, _ = exec_kubectl(
         args=[


### PR DESCRIPTION
The logs watch is not stable for long running pods, since the `kubectl` connection drops sometimes making the jobs flaky.

We don't really need to watch the logs during the tests, so we can just get the logs when the tests finish.