### PR TITLE
Restrict `[sig-network]` Networking Granular Checks

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -93,6 +93,6 @@ presets:
     preset-test-regex: "true"
   env:
   - name: TEST_FOCUS_REGEX
-    value: \\[Conformance\\]|\\[NodeConformance\\]|\\[sig-windows\\]|\\[sig-apps\\].CronJob|\\[sig-api-machinery\\].ResourceQuota|\\[sig-scheduling\\].SchedulerPreemption|\\[sig-network\\].Networking.Granular.Checks
+    value: \\[Conformance\\]|\\[NodeConformance\\]|\\[sig-windows\\]|\\[sig-apps\\].CronJob|\\[sig-api-machinery\\].ResourceQuota|\\[sig-scheduling\\].SchedulerPreemption
   - name: TEST_SKIP_REGEX
-    value: \\[LinuxOnly\\]|\\[Serial\\]|\\[alpha\\]|GMSA|\\[Feature\\:GPUDevicePlugin\\]|\\[sig-api-machinery\\].Garbage.collector|\\[Feature\\:SCTPConnectivity\\]|\\[Disruptive\\]|should.function.for.service.endpoints.using.hostNetwork
+    value: \\[LinuxOnly\\]|\\[Serial\\]|\\[alpha\\]|GMSA|\\[Feature\\:GPUDevicePlugin\\]|\\[sig-api-machinery\\].Garbage.collector

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -187,8 +187,8 @@ periodics:
       command:
         - /workspace/entrypoint.sh
       args:
-        - --test-focus-regex=$(TEST_FOCUS_REGEX)
-        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]
+        - --test-focus-regex=$(TEST_FOCUS_REGEX)|\[sig-network\].Networking.Granular.Checks
+        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]|\[Feature\:SCTPConnectivity\]|\[Disruptive\]|should.function.for.service.endpoints.using.hostNetwork
         - --flake-attempts=2
         - aks
         - --aks-version=1.24
@@ -210,8 +210,8 @@ periodics:
       command:
         - /workspace/entrypoint.sh
       args:
-        - --test-focus-regex=$(TEST_FOCUS_REGEX)
-        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]
+        - --test-focus-regex=$(TEST_FOCUS_REGEX)|\[sig-network\].Networking.Granular.Checks
+        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]|\[Feature\:SCTPConnectivity\]|\[Disruptive\]|should.function.for.service.endpoints.using.hostNetwork
         - --flake-attempts=2
         - aks
         - --aks-version=1.25
@@ -233,8 +233,8 @@ periodics:
       command:
         - /workspace/entrypoint.sh
       args:
-        - --test-focus-regex=$(TEST_FOCUS_REGEX)
-        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]
+        - --test-focus-regex=$(TEST_FOCUS_REGEX)|\[sig-network\].Networking.Granular.Checks
+        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]|\[Feature\:SCTPConnectivity\]|\[Disruptive\]|should.function.for.service.endpoints.using.hostNetwork
         - --flake-attempts=2
         - aks
         - --aks-version=1.25
@@ -256,8 +256,8 @@ periodics:
       command:
         - /workspace/entrypoint.sh
       args:
-        - --test-focus-regex=$(TEST_FOCUS_REGEX)
-        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]
+        - --test-focus-regex=$(TEST_FOCUS_REGEX)|\[sig-network\].Networking.Granular.Checks
+        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]|\[Feature\:SCTPConnectivity\]|\[Disruptive\]|should.function.for.service.endpoints.using.hostNetwork
         - --flake-attempts=2
         - aks
         - --aks-version=1.26
@@ -279,8 +279,8 @@ periodics:
       command:
         - /workspace/entrypoint.sh
       args:
-        - --test-focus-regex=$(TEST_FOCUS_REGEX)
-        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]
+        - --test-focus-regex=$(TEST_FOCUS_REGEX)|\[sig-network\].Networking.Granular.Checks
+        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]|\[Feature\:SCTPConnectivity\]|\[Disruptive\]|should.function.for.service.endpoints.using.hostNetwork
         - --flake-attempts=2
         - aks
         - --aks-version=1.26


### PR DESCRIPTION
Only run these tests on the following Prowjobs:
- AKS 1.24 with Windows Server 2022
- AKS 1.25 with Windows Server 2019
- AKS 1.25 with Windows Server 2022
- AKS 1.26 with Windows Server 2019
- AKS 1.26 with Windows Server 2022

The only missing AKS testing configuration is 1.24 with Windows Server
2019. Currently, the new tests flake a lot on this deployment. The tests will be enabled here as well, after the flakiness is resolved.