### PR TITLE
Aks CI/CD updates

### DIFF
--- a/e2e-runner/e2e_runner/ci/aks/aks.py
+++ b/e2e-runner/e2e_runner/ci/aks/aks.py
@@ -105,9 +105,12 @@ class AksCI(e2e_base.CI):
                 "Didn't find any AKS version patch corresponding to "
                 f"orchestrator version {aks_version}"
             )
-        versions.sort()
-        self.logging.info("Using AKS version: %s", versions[-1])
-        return versions[-1]
+        patches = [int(v.split(".")[-1]) for v in versions]
+        patches.sort()
+        version_split = aks_version.split(".")
+        version = f"{version_split[0]}.{version_split[1]}.{patches[-1]}"
+        self.logging.info("Using AKS version: %s", version)
+        return version
 
     def _generate_win_admin_pass(self):
         special_chars = "+-.<=>@_"

--- a/e2e-runner/e2e_runner/cli/run_ci.py
+++ b/e2e-runner/e2e_runner/cli/run_ci.py
@@ -58,12 +58,6 @@ class RunCI(Command):
             help="Retain the testing environment, if the conformance tests "
                  "failed. Useful for debugging purposes.")
         p.add_argument(
-            "--win-private-bins-zip-url",
-            type=str,
-            help="URL of the zip archive with the private binaries to be "
-                 "installed on the Kubernetes Windows agents before running "
-                 "the E2E tests.")
-        p.add_argument(
             "--flake-attempts",
             type=int,
             default=0,

--- a/e2e-runner/e2e_runner/scripts/aks/enable-proxy-terminating-endpoints-feature.ps1
+++ b/e2e-runner/e2e_runner/scripts/aks/enable-proxy-terminating-endpoints-feature.ps1
@@ -3,4 +3,6 @@ $ErrorActionPreference = "Stop"
 $cfg = Get-Content -Path /k/kubeclusterconfig.json | ConvertFrom-Json
 $cfg.Kubernetes.Kubeproxy.FeatureGates += "ProxyTerminatingEndpoints=true"
 $cfg | ConvertTo-Json -Depth 100 | Out-File -Encoding ascii -PSPath /k/kubeclusterconfig.json
+Restart-Service -Name Kubeproxy -Force
+
 Write-Output "Enabled ProxyTerminatingEndpoints kube-proxy feature gate"

--- a/prow/docs/AksTestCases.md
+++ b/prow/docs/AksTestCases.md
@@ -16,7 +16,7 @@
 ||||
 | Node to Pod | ICMP | - |
 ||||
-| Pod to External IP | TCP | <ol><li>`[sig-windows] Hybrid cluster network for all supported CNIs should provide Internet connection for Windows containers using DNS [Feature:Networking-DNS]`</li><li>`[sig-network] LoadBalancers should not have connectivity disruption during rolling update with externalTrafficPolicy=Cluster (only on AKS v1.24)`</li><li>`[sig-network] LoadBalancers should not have connectivity disruption during rolling update with externalTrafficPolicy=Local (only on AKS v1.24)`</li></ol> |
+| Pod to External IP | TCP | <ol><li>`[sig-windows] Hybrid cluster network for all supported CNIs should provide Internet connection for Windows containers using DNS [Feature:Networking-DNS]`</li><li>`[sig-network] LoadBalancers should not have connectivity disruption during rolling update with externalTrafficPolicy=Cluster`</li><li>`[sig-network] LoadBalancers should not have connectivity disruption during rolling update with externalTrafficPolicy=Local`</li></ol> |
 ||||
 | Pod to External IP | UDP | <ol><li>`[sig-windows] Hybrid cluster network for all supported CNIs should provide Internet connection for Linux containers using DNS [Feature:Networking-DNS]`</li><li>`[sig-windows] Hybrid cluster network for all supported CNIs should provide Internet connection for Windows containers using DNS [Feature:Networking-DNS]`</li><ol> |
 ||||

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -165,8 +165,7 @@ periodics:
         - --test-focus-regex=$(TEST_FOCUS_REGEX)|\[sig-network\].LoadBalancers
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --flake-attempts=2
-        - --win-private-bins-zip-url=http://private-bins/proxy_terminating_endpoints.zip
-        - --e2e-bin=https://capzwin.blob.core.windows.net/bin/e2e.test-1.24.6-patched
+        - --e2e-bin=https://capzwin.blob.core.windows.net/bin/e2e.test-1.24-e2e-patched
         - aks
         - --aks-version=1.24
         - --win-agents-sku=Windows2019

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -162,8 +162,8 @@ periodics:
       command:
         - /workspace/entrypoint.sh
       args:
-        - --test-focus-regex=$(TEST_FOCUS_REGEX)|\[sig-network\].LoadBalancers
-        - --test-skip-regex=$(TEST_SKIP_REGEX)
+        - --test-focus-regex=$(TEST_FOCUS_REGEX)|\[sig-network\].Networking.Granular.Checks|\[sig-network\].LoadBalancers
+        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Feature\:SCTPConnectivity\]|\[Disruptive\]|should.function.for.service.endpoints.using.hostNetwork
         - --flake-attempts=2
         - --e2e-bin=https://capzwin.blob.core.windows.net/bin/e2e.test-1.24-e2e-patched
         - aks
@@ -186,9 +186,10 @@ periodics:
       command:
         - /workspace/entrypoint.sh
       args:
-        - --test-focus-regex=$(TEST_FOCUS_REGEX)|\[sig-network\].Networking.Granular.Checks
-        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]|\[Feature\:SCTPConnectivity\]|\[Disruptive\]|should.function.for.service.endpoints.using.hostNetwork
+        - --test-focus-regex=$(TEST_FOCUS_REGEX)|\[sig-network\].Networking.Granular.Checks|\[sig-network\].LoadBalancers
+        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Feature\:SCTPConnectivity\]|\[Disruptive\]|should.function.for.service.endpoints.using.hostNetwork
         - --flake-attempts=2
+        - --e2e-bin=https://capzwin.blob.core.windows.net/bin/e2e.test-1.24-e2e-patched
         - aks
         - --aks-version=1.24
         - --win-agents-sku=Windows2022
@@ -209,9 +210,10 @@ periodics:
       command:
         - /workspace/entrypoint.sh
       args:
-        - --test-focus-regex=$(TEST_FOCUS_REGEX)|\[sig-network\].Networking.Granular.Checks
-        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]|\[Feature\:SCTPConnectivity\]|\[Disruptive\]|should.function.for.service.endpoints.using.hostNetwork
+        - --test-focus-regex=$(TEST_FOCUS_REGEX)|\[sig-network\].Networking.Granular.Checks|\[sig-network\].LoadBalancers
+        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Feature\:SCTPConnectivity\]|\[Disruptive\]|should.function.for.service.endpoints.using.hostNetwork
         - --flake-attempts=2
+        - --e2e-bin=https://capzwin.blob.core.windows.net/bin/e2e.test-1.25-e2e-patched
         - aks
         - --aks-version=1.25
         - --win-agents-sku=Windows2019
@@ -232,9 +234,10 @@ periodics:
       command:
         - /workspace/entrypoint.sh
       args:
-        - --test-focus-regex=$(TEST_FOCUS_REGEX)|\[sig-network\].Networking.Granular.Checks
-        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]|\[Feature\:SCTPConnectivity\]|\[Disruptive\]|should.function.for.service.endpoints.using.hostNetwork
+        - --test-focus-regex=$(TEST_FOCUS_REGEX)|\[sig-network\].Networking.Granular.Checks|\[sig-network\].LoadBalancers
+        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Feature\:SCTPConnectivity\]|\[Disruptive\]|should.function.for.service.endpoints.using.hostNetwork
         - --flake-attempts=2
+        - --e2e-bin=https://capzwin.blob.core.windows.net/bin/e2e.test-1.25-e2e-patched
         - aks
         - --aks-version=1.25
         - --win-agents-sku=Windows2022
@@ -255,9 +258,10 @@ periodics:
       command:
         - /workspace/entrypoint.sh
       args:
-        - --test-focus-regex=$(TEST_FOCUS_REGEX)|\[sig-network\].Networking.Granular.Checks
-        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]|\[Feature\:SCTPConnectivity\]|\[Disruptive\]|should.function.for.service.endpoints.using.hostNetwork
+        - --test-focus-regex=$(TEST_FOCUS_REGEX)|\[sig-network\].Networking.Granular.Checks|\[sig-network\].LoadBalancers
+        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Feature\:SCTPConnectivity\]|\[Disruptive\]|should.function.for.service.endpoints.using.hostNetwork
         - --flake-attempts=2
+        - --e2e-bin=https://capzwin.blob.core.windows.net/bin/e2e.test-1.26-e2e-patched
         - aks
         - --aks-version=1.26
         - --win-agents-sku=Windows2019
@@ -278,9 +282,10 @@ periodics:
       command:
         - /workspace/entrypoint.sh
       args:
-        - --test-focus-regex=$(TEST_FOCUS_REGEX)|\[sig-network\].Networking.Granular.Checks
-        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Slow\]|\[Feature\:SCTPConnectivity\]|\[Disruptive\]|should.function.for.service.endpoints.using.hostNetwork
+        - --test-focus-regex=$(TEST_FOCUS_REGEX)|\[sig-network\].Networking.Granular.Checks|\[sig-network\].LoadBalancers
+        - --test-skip-regex=$(TEST_SKIP_REGEX)|\[Feature\:SCTPConnectivity\]|\[Disruptive\]|should.function.for.service.endpoints.using.hostNetwork
         - --flake-attempts=2
+        - --e2e-bin=https://capzwin.blob.core.windows.net/bin/e2e.test-1.26-e2e-patched
         - aks
         - --aks-version=1.26
         - --win-agents-sku=Windows2022


### PR DESCRIPTION
* Fix `_get_latest_aks_patch` function:
  * The function was not returning the latest patch version for the specified release.
* Remove private HNS patch since this is GA now:
  * Also, explicitly enable `ProxyTerminatingEndpoints` feature gate on AKS clusters that are below 1.26 release.
* Use patched `e2e.test` binary for all the AKS Prowjobs:
  * The patched E2E binaries contain the submitted test for `ProxyTerminatingEndpoints` feature gate, and other fixes that are not yet backported.

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>