### PR TITLE
Use `3h` ginkgo timeout

### DIFF
--- a/e2e-runner/e2e_runner/base.py
+++ b/e2e-runner/e2e_runner/base.py
@@ -139,6 +139,7 @@ class CI(object):
         ginkgoFlags = {
             "trace": "true",
             "v": "true",
+            "timeout": "3h",
             "nodes": self.opts.parallel_test_nodes,
             "focus": self.opts.test_focus_regex,
             "skip": self.opts.test_skip_regex,


### PR DESCRIPTION
As part of the AKS e2e tests, we are running tests marked as `[Slow]`,
so we need to increase the ginkgo timeout (defaults to `1h`).

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>