### PR TITLE
Update global regex for tests

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -93,6 +93,6 @@ presets:
     preset-test-regex: "true"
   env:
   - name: TEST_FOCUS_REGEX
-    value: \\[Conformance\\]|\\[NodeConformance\\]|\\[sig-windows\\]|\\[sig-apps\\].CronJob|\\[sig-api-machinery\\].ResourceQuota|\\[sig-scheduling\\].SchedulerPreemption
+    value: \\[Conformance\\]|\\[NodeConformance\\]|\\[sig-windows\\]
   - name: TEST_SKIP_REGEX
-    value: \\[LinuxOnly\\]|\\[Serial\\]|\\[alpha\\]|GMSA|\\[Feature\\:GPUDevicePlugin\\]|\\[sig-api-machinery\\].Garbage.collector
+    value: \\[LinuxOnly\\]|\\[Serial\\]|\\[Feature\\:GPUDevicePlugin\\]|\\[sig-api-machinery\\].Garbage.collector


### PR DESCRIPTION
Simplify the regex for the tests to run only Windows related tests, and Conformance / NodeConformance.