### PR TITLE
Update AKS ProwJobs

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -103,4 +103,4 @@ presets:
   - name: TEST_FOCUS_REGEX
     value: \\[Conformance\\]|\\[NodeConformance\\]|\\[sig-windows\\]|\\[sig-network\\].Networking.Granular.Checks|\\[sig-network\\].LoadBalancers
   - name: TEST_SKIP_REGEX
-    value: \\[LinuxOnly\\]|\\[Serial\\]|\\[Feature\\:GPUDevicePlugin\\]|\\[Feature\\:SCTPConnectivity\\]|\\[Disruptive\\]|should.function.for.service.endpoints.using.hostNetwork|\\[sig-api-machinery\\]|\\[sig-cli\\]|\\[sig-auth\\]
+    value: \\[LinuxOnly\\]|\\[Serial\\]|\\[Feature\\:GPUDevicePlugin\\]|\\[Feature\\:SCTPConnectivity\\]|\\[Disruptive\\]|should.function.for.service.endpoints.using.hostNetwork|\\[sig-api-machinery\\]|\\[sig-cli\\]|\\[sig-auth\\]|\\[sig-apps\\].*\\[Slow\\]|\\[sig-node\\].*\\[Slow\\]

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -162,7 +162,7 @@ periodics:
       command:
         - /workspace/entrypoint.sh
       args:
-        - --parallel-test-nodes=2
+        - --parallel-test-nodes=1
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --e2e-bin=https://capzwin.blob.core.windows.net/bin/e2e.test-1.24-e2e-patched
@@ -186,7 +186,7 @@ periodics:
       command:
         - /workspace/entrypoint.sh
       args:
-        - --parallel-test-nodes=2
+        - --parallel-test-nodes=1
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --e2e-bin=https://capzwin.blob.core.windows.net/bin/e2e.test-1.24-e2e-patched
@@ -210,7 +210,7 @@ periodics:
       command:
         - /workspace/entrypoint.sh
       args:
-        - --parallel-test-nodes=2
+        - --parallel-test-nodes=1
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --e2e-bin=https://capzwin.blob.core.windows.net/bin/e2e.test-1.25-e2e-patched
@@ -234,7 +234,7 @@ periodics:
       command:
         - /workspace/entrypoint.sh
       args:
-        - --parallel-test-nodes=2
+        - --parallel-test-nodes=1
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --e2e-bin=https://capzwin.blob.core.windows.net/bin/e2e.test-1.25-e2e-patched
@@ -258,7 +258,7 @@ periodics:
       command:
         - /workspace/entrypoint.sh
       args:
-        - --parallel-test-nodes=2
+        - --parallel-test-nodes=1
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --e2e-bin=https://capzwin.blob.core.windows.net/bin/e2e.test-1.26-e2e-patched
@@ -282,7 +282,7 @@ periodics:
       command:
         - /workspace/entrypoint.sh
       args:
-        - --parallel-test-nodes=2
+        - --parallel-test-nodes=1
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --e2e-bin=https://capzwin.blob.core.windows.net/bin/e2e.test-1.26-e2e-patched


### PR DESCRIPTION
* Experiment with running E2E serially to see if it helps with tests flakiness
* Skip `[Slow]` tests that are not `[sig-network]`