### PR TITLE
Update `capz_flannel` CI

### DIFF
--- a/e2e-runner/Dockerfile
+++ b/e2e-runner/Dockerfile
@@ -29,6 +29,12 @@ RUN curl -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION
     mkdir ~/.kube
 ENV KUBECTL_PATH "/usr/local/bin/kubectl"
 
+# Install helm
+RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
+    chmod +x get_helm.sh && \
+    ./get_helm.sh && \
+    rm ./get_helm.sh
+
 WORKDIR /workspace
 
 ADD cleanup-azure-rgs.py /workspace

--- a/e2e-runner/e2e_runner/ci/capz_flannel/flannel/windows/containerd/kube-flannel.yaml.j2
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/flannel/windows/containerd/kube-flannel.yaml.j2
@@ -150,7 +150,7 @@ spec:
         operator: Exists
       initContainers:
       - name: install-cni
-        image: {{ container_image_registry }}/flannel-{{ container_runtime }}-{{ win_os }}:{{ container_image_tag }}
+        image: {{ container_image_registry }}/flannel-containerd-{{ win_os }}:{{ container_image_tag }}
         imagePullPolicy: Always
         command:
         - "%CONTAINER_SANDBOX_MOUNT_POINT%\\flannel\\install-cni.exe"
@@ -170,7 +170,7 @@ spec:
           value: "{{ pod_subnet }}"
       containers:
       - name: kube-flannel
-        image: {{ container_image_registry }}/flannel-{{ container_runtime }}-{{ win_os }}:{{ container_image_tag }}
+        image: {{ container_image_registry }}/flannel-containerd-{{ win_os }}:{{ container_image_tag }}
         imagePullPolicy: Always
         volumeMounts:
         - name: flannel-cfg

--- a/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/windows/containerd/kube-proxy.yaml.j2
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/kube-proxy/windows/containerd/kube-proxy.yaml.j2
@@ -40,7 +40,7 @@ spec:
       - operator: Exists
       initContainers:
       - name: init-kube-proxy
-        image: {{ container_image_registry }}/kube-proxy-{{ container_runtime }}-{{ win_os }}:{{ container_image_tag }}
+        image: {{ container_image_registry }}/kube-proxy-containerd-{{ win_os }}:{{ container_image_tag }}
         imagePullPolicy: Always
         command:
         - "%CONTAINER_SANDBOX_MOUNT_POINT%\\kube-proxy\\init.exe"
@@ -57,7 +57,7 @@ spec:
           mountPath: /var/lib/kube-proxy
       containers:
       - name: kube-proxy
-        image: {{ container_image_registry }}/kube-proxy-{{ container_runtime }}-{{ win_os }}:{{ container_image_tag }}
+        image: {{ container_image_registry }}/kube-proxy-containerd-{{ win_os }}:{{ container_image_tag }}
         imagePullPolicy: Always
         env:
         - name: NODE_NAME

--- a/e2e-runner/e2e_runner/cli/run_ci.py
+++ b/e2e-runner/e2e_runner/cli/run_ci.py
@@ -112,11 +112,6 @@ class RunCI(Command):
     def add_capz_flannel_subparser(self, subparsers):
         p = subparsers.add_parser("capz_flannel")
         p.add_argument(
-            "--container-runtime",
-            default="containerd",
-            choices=["containerd"],
-            help="Container runtime used by the Kubernetes agents.")
-        p.add_argument(
             "--flannel-mode",
             default=e2e_constants.FLANNEL_MODE_OVERLAY,
             choices=[e2e_constants.FLANNEL_MODE_OVERLAY,

--- a/e2e-runner/e2e_runner/constants.py
+++ b/e2e-runner/e2e_runner/constants.py
@@ -30,3 +30,5 @@ DEFAULT_AKS_VERSION = "1.27"
 
 FLANNEL_MODE_OVERLAY = "overlay"
 FLANNEL_MODE_L2BRIDGE = "host-gw"
+
+CLOUD_PROVIDER_AZURE_HELM_REPO = "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo"  # noqa: E501

--- a/e2e-runner/e2e_runner/templates/capz/cluster.yaml.j2
+++ b/e2e-runner/e2e_runner/templates/capz/cluster.yaml.j2
@@ -2,8 +2,6 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
-  labels:
-    cni: flannel-windows
   name: {{ cluster_name }}
   namespace: default
 spec:

--- a/e2e-runner/e2e_runner/templates/capz/control-plane.yaml.j2
+++ b/e2e-runner/e2e_runner/templates/capz/control-plane.yaml.j2
@@ -9,30 +9,13 @@ spec:
     clusterConfiguration:
       apiServer:
         extraArgs:
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
-        extraVolumes:
-        - hostPath: /etc/kubernetes/azure.json
-          mountPath: /etc/kubernetes/azure.json
-          name: cloud-config
-          readOnly: true
+          cloud-provider: external
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:
-          allocate-node-cidrs: "true"
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
+          allocate-node-cidrs: "false"
+          cloud-provider: external
           cluster-name: {{ cluster_name }}
-{%- if flannel_mode == "host-gw" %}
-          configure-cloud-routes: "true"
-{%- else %}
-          configure-cloud-routes: "false"
-{%- endif %}
-        extraVolumes:
-        - hostPath: /etc/kubernetes/azure.json
-          mountPath: /etc/kubernetes/azure.json
-          name: cloud-config
-          readOnly: true
       etcd:
         local:
           dataDir: /var/lib/etcddisk/etcd
@@ -78,8 +61,7 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
+          cloud-provider: external
 {%- raw %}
         name: '{{ ds.meta_data["local_hostname"] }}'
 {%- endraw %}
@@ -87,8 +69,7 @@ spec:
       nodeRegistration:
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
-          cloud-config: /etc/kubernetes/azure.json
-          cloud-provider: azure
+          cloud-provider: external
 {%- raw %}
         name: '{{ ds.meta_data["local_hostname"] }}'
 {%- endraw %}

--- a/e2e-runner/e2e_runner/templates/capz/windows-agents.yaml.j2
+++ b/e2e-runner/e2e_runner/templates/capz/windows-agents.yaml.j2
@@ -66,13 +66,12 @@ spec:
         permissions: "0644"
       joinConfiguration:
         nodeRegistration:
-{%- if container_runtime == "containerd" %}
           criSocket: npipe:////./pipe/containerd-containerd
-{%- endif %}
           kubeletExtraArgs:
             azure-container-registry-config: c:/k/azure.json
-            cloud-config: c:/k/azure.json
-            cloud-provider: azure
+            cloud-provider: external
+            v: "2"
+            windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS
 {%- raw %}
           name: '{{ ds.meta_data["local_hostname"] }}'
 {%- endraw %}


### PR DESCRIPTION
* Remove `--container-runtime` e2e-runner flag, since containerd is the only tested continer runtime.
* Use external Azure cloud provider for kubelet. The cloud provider is installed via Helm.