### PR TITLE
Fix Flannel Kubernets `master` Prowjobs

### DIFF
--- a/e2e-runner/e2e_runner/constants.py
+++ b/e2e-runner/e2e_runner/constants.py
@@ -32,3 +32,4 @@ FLANNEL_MODE_OVERLAY = "overlay"
 FLANNEL_MODE_L2BRIDGE = "host-gw"
 
 CLOUD_PROVIDER_AZURE_HELM_REPO = "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo"  # noqa: E501
+CLOUD_PROVIDER_AZURE_TAGS = "https://api.github.com/repos/kubernetes-sigs/cloud-provider-azure/tags"  # noqa: E501

--- a/e2e-runner/e2e_runner/utils/utils.py
+++ b/e2e-runner/e2e_runner/utils/utils.py
@@ -5,7 +5,7 @@ import tarfile
 import tempfile
 import time
 from collections import OrderedDict
-from urllib.request import urlretrieve
+from urllib.request import urlopen, urlretrieve
 
 import configargparse
 import jinja2
@@ -161,6 +161,12 @@ def make_tgz_archive(source_dir, output_file):
 @retry_on_error()
 def download_file(url, dest):
     urlretrieve(url, dest)
+
+
+@retry_on_error()
+def url_get(url):
+    with urlopen(url) as f:
+        return f.read().decode()
 
 
 def sort_dict_by_value(d):


### PR DESCRIPTION
We need to explicitly set the Azure cloud-provider image tag when deploying Kubernetes latest `master` branch code.