### PR TITLE
Update capz flannel CI dependencies

### DIFF
--- a/e2e-runner/Dockerfile
+++ b/e2e-runner/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-ARG CAPI_VERSION=v1.3.3
+ARG CAPI_VERSION=v1.5.2
 ARG KUBECTL_VERSION=v1.27.1
 
 # Install system APT packages & dependencies

--- a/e2e-runner/e2e_runner/ci/capz_flannel/bootstrap_vm.py
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/bootstrap_vm.py
@@ -329,8 +329,8 @@ class BootstrapVM(object):
         return compute_models.StorageProfile(
             image_reference=compute_models.ImageReference(
                 publisher="Canonical",
-                offer="0001-com-ubuntu-server-focal",
-                sku="20_04-lts-gen2",
+                offer="0001-com-ubuntu-server-jammy",
+                sku="22_04-lts-gen2",
                 version="latest",
             ),
             os_disk=compute_models.OSDisk(

--- a/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
@@ -100,7 +100,7 @@ class CapzFlannelCI(e2e_base.CI):
 
     @property
     def capz_images_ubuntu_sku(self):
-        return "ubuntu-2004-gen1"
+        return "ubuntu-2204-gen1"
 
     @property
     def capz_images_windows_sku(self):

--- a/e2e-runner/e2e_runner/ci/capz_flannel/cloud-init/install-kind.sh
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/cloud-init/install-kind.sh
@@ -3,7 +3,7 @@ set -o nounset
 set -o pipefail
 set -o errexit
 
-KIND_BIN_URL="https://github.com/kubernetes-sigs/kind/releases/download/v0.17.0/kind-linux-amd64"
+KIND_BIN_URL="https://github.com/kubernetes-sigs/kind/releases/download/v0.20.0/kind-linux-amd64"
 
 sudo curl -s -L -o /usr/local/bin/kind $KIND_BIN_URL
 sudo chmod +x /usr/local/bin/kind

--- a/e2e-runner/e2e_runner/ci/capz_flannel/cloud-init/userdata
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/cloud-init/userdata
@@ -12,7 +12,6 @@ packages:
   - build-essential
   - ca-certificates
   - curl
-  - curl
   - docker-ce
   - docker-ce-cli
   - git


### PR DESCRIPTION
* Remove cri-tools installation from Windows nodes:
  * This is not needed for normal operation of Kubernetes Windows agents.
* Bump kind to `v0.20.0`
* Bump bootstrap VM to Ubuntu 22.04
* Bump default Kubernetes version to `v1.28.1` for `capz_flannel` CI
* Bump `CAPI_VERSION` to `v1.5.2`