### PR TITLE
Fix Kubernetes `master` Prowjobs

### DIFF
--- a/e2e-runner/e2e_runner/scripts/kubeadm-bootstrap.ps1
+++ b/e2e-runner/e2e_runner/scripts/kubeadm-bootstrap.ps1
@@ -162,7 +162,6 @@ function Update-Containerd {
     foreach($bin in $binaries) {
         Install-CIBinary "$CIPackagesBaseURL/containerd/bin/$bin" "$CONTAINERD_DIR\$bin"
     }
-    Add-ToServiceEnv -ServiceName "containerd" -Name "DISABLE_CRI_SANDBOXES" -Value "1"
     Start-Service -Name "containerd"
 }
 

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -18,7 +18,6 @@ periodics:
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --build=k8sbins
-        - --build=containerdbins
         - --build=sdncnibins
         - capz_flannel
         - --flannel-mode=host-gw
@@ -44,7 +43,6 @@ periodics:
         - --test-focus-regex=$(TEST_FOCUS_REGEX)
         - --test-skip-regex=$(TEST_SKIP_REGEX)
         - --build=k8sbins
-        - --build=containerdbins
         - --build=sdncnibins
         - capz_flannel
         - --flannel-mode=overlay


### PR DESCRIPTION
* Do not set `DISABLE_CRI_SANDBOXES`:
  * This doesn't work anymore, since the CRI legacy implementation is removed now.
* Do not build latest `main` containerd:
  * There is a known regression with latest containerd and sandboxed CRI. Re-enable containerd builds once the issue is fixed https://github.com/containerd/containerd/issues/9037.