### PR TITLE
Update Kubernetes master branch Prowjobs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,7 @@
 {
     "configurations": [
         {
-            "name": "k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-master",
+            "name": "k8s-e2e-ltsc2022-containerd-flannel-sdnbridge-master",
             "type": "docker",
             "request": "launch",
             "preLaunchTask": "docker-run: debug",
@@ -23,13 +23,13 @@
                     "--build=sdncnibins",
                     "capz_flannel",
                     "--flannel-mode=host-gw",
-                    "--win-os=ltsc2019",
+                    "--win-os=ltsc2022",
                     "--cluster-name=capzctrd"
                 ]
             }
         },
         {
-            "name": "k8s-e2e-ltsc2019-containerd-flannel-sdnoverlay-master",
+            "name": "k8s-e2e-ltsc2022-containerd-flannel-sdnoverlay-master",
             "type": "docker",
             "request": "launch",
             "preLaunchTask": "docker-run: debug",
@@ -51,7 +51,7 @@
                     "--build=sdncnibins",
                     "capz_flannel",
                     "--flannel-mode=overlay",
-                    "--win-os=ltsc2019",
+                    "--win-os=ltsc2022",
                     "--cluster-name=capzctrd"
                 ]
             }

--- a/e2e-runner/e2e_runner/cli/run_ci.py
+++ b/e2e-runner/e2e_runner/cli/run_ci.py
@@ -174,7 +174,7 @@ class RunCI(Command):
             help="The node subnet CIDR block.")
         p.add_argument(
             "--bootstrap-vm-size",
-            default="Standard_D2s_v3",
+            default="Standard_D8s_v3",
             help="Size of the bootstrap VM.")
         p.add_argument(
             "--master-vm-size",

--- a/e2e-runner/e2e_runner/cli/run_ci.py
+++ b/e2e-runner/e2e_runner/cli/run_ci.py
@@ -187,7 +187,7 @@ class RunCI(Command):
             help="Number of K8s Windows agents for the deployment.")
         p.add_argument(
             "--win-os",
-            default="ltsc2019",
+            default="ltsc2022",
             choices=["ltsc2019", "ltsc2022"],
             help="The operating system of the K8s Windows agents.")
         p.add_argument(

--- a/e2e-runner/e2e_runner/constants.py
+++ b/e2e-runner/e2e_runner/constants.py
@@ -31,5 +31,5 @@ DEFAULT_AKS_VERSION = "1.27"
 FLANNEL_MODE_OVERLAY = "overlay"
 FLANNEL_MODE_L2BRIDGE = "host-gw"
 
-CLOUD_PROVIDER_AZURE_HELM_REPO = "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/helm/repo"  # noqa: E501
+CLOUD_PROVIDER_AZURE_HELM_REPO = "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/{}/helm/repo"  # noqa: E501
 CLOUD_PROVIDER_AZURE_TAGS = "https://api.github.com/repos/kubernetes-sigs/cloud-provider-azure/tags"  # noqa: E501

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-master
+- name: k8s-e2e-ltsc2022-containerd-flannel-sdnbridge-master
   cron: "0 0 */2 * *"
   always_run: true
   labels:
@@ -20,10 +20,10 @@ periodics:
         - --build=sdncnibins
         - capz_flannel
         - --flannel-mode=host-gw
-        - --win-os=ltsc2019
+        - --win-os=ltsc2022
         - --cluster-name=capzctrd
 
-- name: k8s-e2e-ltsc2019-containerd-flannel-sdnoverlay-master
+- name: k8s-e2e-ltsc2022-containerd-flannel-sdnoverlay-master
   cron: "0 6 */2 * *"
   always_run: true
   labels:
@@ -44,7 +44,7 @@ periodics:
         - --build=sdncnibins
         - capz_flannel
         - --flannel-mode=overlay
-        - --win-os=ltsc2019
+        - --win-os=ltsc2022
         - --cluster-name=capzctrd
 
 - name: k8s-e2e-ltsc2019-containerd-flannel-sdnbridge-stable

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -3,7 +3,6 @@ periodics:
   cron: "0 0 */2 * *"
   always_run: true
   labels:
-    preset-flannel-test-regex: "true"
     preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
@@ -28,7 +27,6 @@ periodics:
   cron: "0 6 */2 * *"
   always_run: true
   labels:
-    preset-flannel-test-regex: "true"
     preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
@@ -53,7 +51,6 @@ periodics:
   cron: "0 1 */2 * *"
   always_run: true
   labels:
-    preset-flannel-test-regex: "true"
     preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
@@ -76,7 +73,6 @@ periodics:
   cron: "0 3 */2 * *"
   always_run: true
   labels:
-    preset-flannel-test-regex: "true"
     preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
@@ -99,7 +95,6 @@ periodics:
   cron: "0 5 */2 * *"
   always_run: true
   labels:
-    preset-flannel-test-regex: "true"
     preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
@@ -122,7 +117,6 @@ periodics:
   cron: "0 7 */2 * *"
   always_run: true
   labels:
-    preset-flannel-test-regex: "true"
     preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
@@ -145,7 +139,7 @@ periodics:
   cron: "0 4 * * *"
   always_run: true
   labels:
-    preset-aks-test-regex: "true"
+    preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
     preset-windows-private-registry-cred: "true"
@@ -168,7 +162,7 @@ periodics:
   cron: "0 10 * * *"
   always_run: true
   labels:
-    preset-aks-test-regex: "true"
+    preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
     preset-windows-private-registry-cred: "true"
@@ -191,7 +185,7 @@ periodics:
   cron: "0 9 * * *"
   always_run: true
   labels:
-    preset-aks-test-regex: "true"
+    preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
     preset-windows-private-registry-cred: "true"
@@ -214,7 +208,7 @@ periodics:
   cron: "0 15 * * *"
   always_run: true
   labels:
-    preset-aks-test-regex: "true"
+    preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
     preset-windows-private-registry-cred: "true"
@@ -237,7 +231,7 @@ periodics:
   cron: "0 2 * * *"
   always_run: true
   labels:
-    preset-aks-test-regex: "true"
+    preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
     preset-windows-private-registry-cred: "true"
@@ -260,7 +254,7 @@ periodics:
   cron: "0 8 * * *"
   always_run: true
   labels:
-    preset-aks-test-regex: "true"
+    preset-github-readonly-token: "true"
     preset-ssh-key: "true"
     preset-prod-azure-account: "true"
     preset-windows-private-registry-cred: "true"


### PR DESCRIPTION
- Update bootstrap VM size to `Standard_D8s_v3`.
- Update Prowjobs presets.
- Use azure cloud provider helm repo from stable branch.
- Use LTSC 2022 for Kubernetes master branch Prowjobs:
  - Also, update `--win-os` parameter default value to `ltsc2022`.