### PR TITLE
Prow Cluster Updates

### DIFF
--- a/.github/workflows/prow-cronjobs.yaml
+++ b/.github/workflows/prow-cronjobs.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  KUBECTL_VERSION: v1.24.3  # Corresponds to the Prow K8s environment
+  KUBECTL_VERSION: v1.28.3  # Corresponds to the Prow K8s environment
 
 jobs:
   prow-cronjobs:

--- a/prow/Makefile
+++ b/prow/Makefile
@@ -5,11 +5,11 @@ all: update-prow-config update-prow-plugins update-prow-job-config
 
 .PHONY: update-prow-config
 update-prow-config:
-	kubectl create configmap -n prow config --from-file=config.yaml=config.yaml -o yaml --dry-run=client | kubectl apply -f -
+	kubectl create configmap -n prow config --from-file=config.yaml=config.yaml -o yaml --dry-run=client | kubectl replace configmap -f -
 
 .PHONY: update-prow-plugins
 update-prow-plugins:
-	kubectl create configmap -n prow plugins --from-file=plugins.yaml=plugins.yaml -o yaml --dry-run=client | kubectl apply -f -
+	kubectl create configmap -n prow plugins --from-file=plugins.yaml=plugins.yaml -o yaml --dry-run=client | kubectl replace configmap -f -
 
 .PHONY: update-prow-job-config
 update-prow-job-config:

--- a/prow/backup/Dockerfile
+++ b/prow/backup/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 # Corresponds to the Prow K8s environment
-ENV KUBECTL_VERSION=v1.24.3
+ENV KUBECTL_VERSION=v1.28.3
 
 # Install APT packages
 ENV DEBIAN_FRONTEND=noninteractive

--- a/prow/cluster.yaml
+++ b/prow/cluster.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20230329-c93d79fb7d
+        image: gcr.io/k8s-prow/hook:v20231130-2f95ffc454
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -126,7 +126,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20230329-c93d79fb7d
+        image: gcr.io/k8s-prow/sinker:v20231130-2f95ffc454
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
@@ -172,7 +172,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20230329-c93d79fb7d
+        image: gcr.io/k8s-prow/deck:v20231130-2f95ffc454
         args:
         - --config-path=/etc/config/config.yaml
         - --plugin-config=/etc/plugins/plugins.yaml
@@ -275,7 +275,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20230329-c93d79fb7d
+        image: gcr.io/k8s-prow/horologium:v20231130-2f95ffc454
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -317,7 +317,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20230329-c93d79fb7d
+        image: gcr.io/k8s-prow/tide:v20231130-2f95ffc454
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -433,7 +433,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20230329-c93d79fb7d
+        image: gcr.io/k8s-prow/status-reconciler:v20231130-2f95ffc454
         args:
         - --dry-run=false
         - --continue-on-error=true
@@ -832,7 +832,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20230329-c93d79fb7d
+        image: gcr.io/k8s-prow/ghproxy:v20231130-2f95ffc454
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99
@@ -901,7 +901,7 @@ spec:
             secretKeyRef:
               name: github-token
               key: appid
-        image: gcr.io/k8s-prow/prow-controller-manager:v20230329-c93d79fb7d
+        image: gcr.io/k8s-prow/prow-controller-manager:v20231130-2f95ffc454
         volumeMounts:
         - name: github-token
           mountPath: /etc/github
@@ -1043,7 +1043,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20230329-c93d79fb7d
+        image: gcr.io/k8s-prow/crier:v20231130-2f95ffc454
         args:
         - --blob-storage-workers=10
         - --config-path=/etc/config/config.yaml

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -11,10 +11,10 @@ plank:
       gcs_credentials_secret: gcs-credentials
       skip_cloning: true
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20230329-c93d79fb7d
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20230329-c93d79fb7d
-        initupload: gcr.io/k8s-prow/initupload:v20230329-c93d79fb7d
-        sidecar: gcr.io/k8s-prow/sidecar:v20230329-c93d79fb7d
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20231130-2f95ffc454
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20231130-2f95ffc454
+        initupload: gcr.io/k8s-prow/initupload:v20231130-2f95ffc454
+        sidecar: gcr.io/k8s-prow/sidecar:v20231130-2f95ffc454
 
 sinker:
   max_prowjob_age: 336h # 2 weeks

--- a/prow/docs/ProwAksUpgrade.md
+++ b/prow/docs/ProwAksUpgrade.md
@@ -1,0 +1,53 @@
+# Prow on AKS Upgrade
+
+## Upgrade AKS cluster
+
+Check if the AKS cluster has any upgrades available:
+
+```bash
+$ az aks get-upgrades -g k8s-sig-windows-networking -n sig-win-networking-prow -o table
+Name     ResourceGroup               MasterVersion    Upgrades
+-------  --------------------------  ---------------  --------------
+default  k8s-sig-windows-networking  1.27.7           1.28.0, 1.28.3
+```
+
+For example, the above AKS cluster is deployed with version `1.27.7` and has two upgrades available: `1.28.0` and `1.28.3`.
+
+Upgrade the AKS cluster to the latest upgrade version available:
+
+```bash
+az aks upgrade -g k8s-sig-windows-networking -n sig-win-networking-prow --kubernetes-version 1.28.3
+```
+
+NOTE: You can only upgrade one major version at a time. For example, if your cluster is running version 1.27, you can upgrade to 1.28, but not to 1.29 or later. The upgrade to 1.29 (or later) requires two steps: 1.27 -> 1.28, then 1.28 -> 1.29.
+
+## Upgrade Prow
+
+The [prow/cluster.yaml](https://github.com/e2e-win/k8s-e2e-runner/blob/main/prow/cluster.yaml) file contains the full Prow deployment used. This is derived from the upstream [prow/starter-gcs.yaml](https://github.com/kubernetes/test-infra/blob/master/config/prow/cluster/starter/starter-gcs.yaml) file, since we also use a GCS bucket to publish Prowjobs artifacts.
+
+When a Prow upgrade is needed, we need to compare [prow/cluster.yaml](https://github.com/e2e-win/k8s-e2e-runner/blob/main/prow/cluster.yaml) with the upstream [prow/starter-gcs.yaml](https://github.com/kubernetes/test-infra/blob/master/config/prow/cluster/starter/starter-gcs.yaml) file. Unless there are major changes to the Prow components, we only need to update the image version tags in:
+
+* [prow/cluster.yaml](https://github.com/e2e-win/k8s-e2e-runner/blob/main/prow/cluster.yaml), for all the Prow components.
+* [prow/config.yaml](https://github.com/e2e-win/k8s-e2e-runner/blob/main/prow/config.yaml), for the `utility_images`.
+
+Keep in mind that the existing AKS Prow deployment uses:
+
+* A minimal `config.yaml` saved in the `config` configmap.
+* A minimal `plugins.yaml` saved in the `plugins` configmap.
+* A separate `job-config` configmap with the periodic jobs, populated from [prow/jobs/sig-windows-networking.yaml](https://github.com/e2e-win/k8s-e2e-runner/blob/main/prow/jobs/sig-windows-networking.yaml) file.
+* Traefik ingress controller instead of Nginx ingress controller (so different annotations are given to the Prow `Ingress` resource).
+
+These are all the specific differences of the AKS Prow [cluster.yaml](https://github.com/e2e-win/k8s-e2e-runner/blob/main/prow/cluster.yaml) compared to the upstream [prow/starter-gcs.yaml](https://github.com/kubernetes/test-infra/blob/master/config/prow/cluster/starter/starter-gcs.yaml) deployment.
+
+After the changes are made, we need to apply them via:
+
+```bash
+# change directory to "prow" directory of the local k8s-e2e-runner repo clone.
+cd <path-to-k8s-e2e-runner>/prow
+
+# update the Prow Kubernetes cluster.
+kubectl apply -f cluster.yaml
+
+# update the main Prow configmap.
+make update-prow-config
+```


### PR DESCRIPTION
* Bump `KUBECTL_VERSION` to match the Prow AKS cluster.
* Update `prow/Makefile`:
  * Use `kubectl replace configmap` for all the make targets that update configmaps.
* Upgrade Prow components:
  * Bump Prow image tags to `v20231130-2f95ffc454`.
* Add `prow/docs/ProwAksUpgrade.md` documentation.