### PR TITLE
Remove deprecated azure container registry config flag

### DIFF
--- a/e2e-runner/e2e_runner/templates/capz/control-plane.yaml.j2
+++ b/e2e-runner/e2e_runner/templates/capz/control-plane.yaml.j2
@@ -60,7 +60,6 @@ spec:
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          azure-container-registry-config: /etc/kubernetes/azure.json
           cloud-provider: external
 {%- raw %}
         name: '{{ ds.meta_data["local_hostname"] }}'
@@ -68,7 +67,6 @@ spec:
     joinConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          azure-container-registry-config: /etc/kubernetes/azure.json
           cloud-provider: external
 {%- raw %}
         name: '{{ ds.meta_data["local_hostname"] }}'

--- a/e2e-runner/e2e_runner/templates/capz/windows-agents.yaml.j2
+++ b/e2e-runner/e2e_runner/templates/capz/windows-agents.yaml.j2
@@ -68,7 +68,6 @@ spec:
         nodeRegistration:
           criSocket: npipe:////./pipe/containerd-containerd
           kubeletExtraArgs:
-            azure-container-registry-config: c:/k/azure.json
             cloud-provider: external
             v: "2"
             windows-priorityclass: ABOVE_NORMAL_PRIORITY_CLASS


### PR DESCRIPTION
Following removal of in tree cloud provider code, azure-container-registry-config is deprecated: https://github.com/kubernetes-sigs/windows-testing/pull/420