### PR TITLE
Deprecate Node Kube Proxy Version check 

### DIFF
--- a/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
@@ -844,18 +844,10 @@ class CapzFlannelCI(e2e_base.CI):
 
             kube_proxy_ver = node["status"]["nodeInfo"]["kubeProxyVersion"]
             # Deprecated KubeProxy Version Reporting: https://github.com/kubernetes/kubernetes/commit/98c29f0312190904f55d62a4b4820fc17119ec10 
-            parts = kube_proxy_ver.strip("v").split(".")
-            processed_version = int(''.join(parts[:2]))
-            if processed_version >= 131:
-                if kube_proxy_ver != "":
-                    raise e2e_exceptions.VersionMismatch(
-                        f"Wrong kube-proxy version on node {node_name}. "
-                        f"Expected {expected_ver}, but found {kube_proxy_ver}")
-            else:
-                if kube_proxy_ver != expected_ver:
-                    raise e2e_exceptions.VersionMismatch(
-                        f"Wrong kube-proxy version on node {node_name}. "
-                        f"Expected {expected_ver}, but found {kube_proxy_ver}")
+            if kube_proxy_ver != "" and kube_proxy_ver != expected_ver:
+                raise e2e_exceptions.VersionMismatch(
+                    f"Wrong kube-proxy version on node {node_name}. "
+                    f"Expected {expected_ver}, but found {kube_proxy_ver}")
 
     def _cleanup_capz_cluster(self):
         self._collect_bootstrap_vm_logs()

--- a/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
@@ -843,7 +843,8 @@ class CapzFlannelCI(e2e_base.CI):
                     f"Expected {expected_ver}, but found {kubelet_ver}")
 
             kube_proxy_ver = node["status"]["nodeInfo"]["kubeProxyVersion"]
-            if kube_proxy_ver != expected_ver:
+            # Deprecated KubeProxy Version Reporting: https://github.com/kubernetes/kubernetes/commit/98c29f0312190904f55d62a4b4820fc17119ec10 
+            if kube_proxy_ver != "":
                 raise e2e_exceptions.VersionMismatch(
                     f"Wrong kube-proxy version on node {node_name}. "
                     f"Expected {expected_ver}, but found {kube_proxy_ver}")

--- a/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
@@ -844,10 +844,18 @@ class CapzFlannelCI(e2e_base.CI):
 
             kube_proxy_ver = node["status"]["nodeInfo"]["kubeProxyVersion"]
             # Deprecated KubeProxy Version Reporting: https://github.com/kubernetes/kubernetes/commit/98c29f0312190904f55d62a4b4820fc17119ec10 
-            if kube_proxy_ver != "":
-                raise e2e_exceptions.VersionMismatch(
-                    f"Wrong kube-proxy version on node {node_name}. "
-                    f"Expected {expected_ver}, but found {kube_proxy_ver}")
+            parts = kube_proxy_ver.strip("v").split(".")
+            processed_version = int(''.join(parts[:2]))
+            if processed_version >= 131:
+                if kube_proxy_ver != "":
+                    raise e2e_exceptions.VersionMismatch(
+                        f"Wrong kube-proxy version on node {node_name}. "
+                        f"Expected {expected_ver}, but found {kube_proxy_ver}")
+            else:
+                if kube_proxy_ver != expected_ver:
+                    raise e2e_exceptions.VersionMismatch(
+                        f"Wrong kube-proxy version on node {node_name}. "
+                        f"Expected {expected_ver}, but found {kube_proxy_ver}")
 
     def _cleanup_capz_cluster(self):
         self._collect_bootstrap_vm_logs()


### PR DESCRIPTION
Fix for ltsc2022 E2E runner failures on kube proxy version mismatch  for sdnbridge and sdnoverlay master branches as a result of this  PR: https://github.com/kubernetes/kubernetes/commit/98c29f0312190904f55d62a4b4820fc17119ec10

Failure log:
File "/usr/local/lib/python3.10/dist-packages/e2e_runner/ci/capz_flannel/capz_flannel.py", line 457, in _setup_capz_cluster
    self._validate_k8s_api_versions()
  File "/usr/local/lib/python3.10/dist-packages/e2e_runner/ci/capz_flannel/capz_flannel.py", line 847, in _validate_k8s_api_versions
    raise e2e_exceptions.VersionMismatch(
e2e_runner.exceptions.VersionMismatch: Wrong kube-proxy version on node capzctrd-1715925611-control-plane-qctvr. Expected v1.31.0-alpha.0.803+5ceb99dc6bae8a, but found 

