### PR TITLE
Add Server 2025 Tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,66 @@
 {
     "configurations": [
         {
+            "name": "k8s-e2e-ltsc2025-containerd-flannel-sdnbridge-master",
+            "type": "docker",
+            "request": "launch",
+            "preLaunchTask": "docker-run: debug",
+            "python": {
+                "pathMappings": [
+                    {
+                        "localRoot": "${workspaceFolder}/e2e-runner",
+                        "remoteRoot": "/app"
+                    }
+                ],
+                "projectType": "general",
+                "args": [
+                    "run",
+                    "ci",
+                    "--quiet",
+                    "--test-regex-file-url=https://raw.githubusercontent.com/e2e-win/k8s-e2e-runner/main/prow/test-regex/capz_flannel.yaml",
+                    "--build=k8sbins",
+                    "--build=containerdbins",
+                    "--build=sdncnibins",
+                    "capz_flannel",
+                    "--cni-version=1.0.0",
+                    "--bootstrap-vm-size=Standard_D8s_v3",
+                    "--flannel-mode=host-gw",
+                    "--win-os=ltsc2025",
+                    "--cluster-name=capzctrd"
+                ]
+            }
+        },
+        {
+            "name": "k8s-e2e-ltsc2025-containerd-flannel-sdnoverlay-master",
+            "type": "docker",
+            "request": "launch",
+            "preLaunchTask": "docker-run: debug",
+            "python": {
+                "pathMappings": [
+                    {
+                        "localRoot": "${workspaceFolder}/e2e-runner",
+                        "remoteRoot": "/app"
+                    }
+                ],
+                "projectType": "general",
+                "args": [
+                    "run",
+                    "ci",
+                    "--quiet",
+                    "--test-regex-file-url=https://raw.githubusercontent.com/e2e-win/k8s-e2e-runner/main/prow/test-regex/capz_flannel.yaml",
+                    "--build=k8sbins",
+                    "--build=containerdbins",
+                    "--build=sdncnibins",
+                    "capz_flannel",
+                    "--cni-version=1.0.0",
+                    "--bootstrap-vm-size=Standard_D8s_v3",
+                    "--flannel-mode=vxlan",
+                    "--win-os=ltsc2025",
+                    "--cluster-name=capzctrd"
+                ]
+            }
+        },
+        {
             "name": "k8s-e2e-ltsc2022-containerd-flannel-sdnbridge-master",
             "type": "docker",
             "request": "launch",

--- a/e2e-runner/Dockerfile
+++ b/e2e-runner/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 ARG CAPI_VERSION=v1.8.4
-ARG KUBECTL_VERSION=v1.29.11
+ARG KUBECTL_VERSION=v1.30.6
 
 # Install system APT packages & dependencies
 ENV DEBIAN_FRONTEND=noninteractive

--- a/e2e-runner/Dockerfile
+++ b/e2e-runner/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
-ARG CAPI_VERSION=v1.5.3
-ARG KUBECTL_VERSION=v1.28.4
+ARG CAPI_VERSION=v1.8.4
+ARG KUBECTL_VERSION=v1.29.11
 
 # Install system APT packages & dependencies
 ENV DEBIAN_FRONTEND=noninteractive

--- a/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
@@ -123,6 +123,14 @@ class CapzFlannelCI(e2e_base.CI):
     @property
     def capz_sig_windows_image_name(self):
         return f"capi-win-{self.os_version}-containerd"
+    
+    @property
+    def capz_sig_ubuntu_image_name(self):
+        return f"capi-ubun2-2404"
+
+    @property
+    def capz_sig_image_gallery(self):
+        return f"ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019"
 
     @property
     def k8s_path(self):
@@ -537,7 +545,10 @@ class CapzFlannelCI(e2e_base.CI):
         ssh_public_key_b64 = base64.b64encode(
             self.ssh_public_key.encode()).decode()  # pyright: ignore
         capz_image_ubuntu_version = self._capz_image_latest_version(
-            self.capz_images_linux_offer, self.capz_images_ubuntu_sku
+            self.capz_sig_image_gallery, self.capz_sig_ubuntu_image_name
+        )
+        capz_image_windows_version = self._capz_image_latest_version(
+            self.capz_sig_image_gallery, self.capz_sig_windows_image_name
         )
         context = {
             "cluster_name": self.opts.cluster_name,
@@ -571,12 +582,11 @@ class CapzFlannelCI(e2e_base.CI):
             "containerd_bins": "containerdbins" in self.bins_built,
             "containerd_shim_bins": "containerdshim" in self.bins_built,
 
-            "capz_image_publisher": self.capz_images_publisher,
-            "capz_image_ubuntu_offer": self.capz_images_linux_offer,
-            "capz_image_ubuntu_sku": self.capz_images_ubuntu_sku,
-            "capz_image_ubuntu_version": capz_image_ubuntu_version,
+            "capz_sig_ubuntu_image_name": self.capz_sig_ubuntu_image_name,
+            "capz_sig_ubuntu_image_version": capz_image_ubuntu_version,
+
             "capz_sig_windows_image_name": self.capz_sig_windows_image_name,
-            "capz_sig_windows_image_version": self.opts.kubernetes_version
+            "capz_sig_windows_image_version": capz_image_windows_version
         }
         return context
 
@@ -586,16 +596,22 @@ class CapzFlannelCI(e2e_base.CI):
             ver = e2e_constants.DEFAULT_KUBERNETES_VERSION
         v = ver.strip("v").split(".")
         return f"{v[0]}{v[1]}.{v[2]}"
+    
+    def _capz_sig_gallery_version_prefix(self):
+        ver = self.kubernetes_version
+        if "k8sbins" in self.bins_built:
+            ver = e2e_constants.DEFAULT_KUBERNETES_VERSION
+        v = ver.strip("v").split(".")
+        return f"{v[0]}.{v[1]}"
 
-    def _capz_image_latest_version(self, offer, sku):
+    def _capz_image_latest_version(self, gallery_name, image_name):
         img_vers = e2e_utils.retry_on_error()(
-            self.compute_client.virtual_machine_images.list)(
-                self.location,
-                self.capz_images_publisher,
-                offer,  # pyright: ignore
-                sku,  # pyright: ignore
-        )
-        prefix = self._capz_images_version_prefix()
+            self.compute_client.community_gallery_image_versions.list)(
+                location=self.location,
+                public_gallery_name=gallery_name,
+                gallery_image_name=image_name
+            )
+        prefix = self._capz_sig_gallery_version_prefix()
         vers = [i.name for i in img_vers if i.name.startswith(prefix)]
         vers.sort()
         return vers[-1]
@@ -841,19 +857,20 @@ class CapzFlannelCI(e2e_base.CI):
         )
         nodes = yaml.safe_load(nodes_yaml)  # pyright: ignore
 
-        expected_ver = self.kubernetes_version
+        expected_ver = f"v{self._capz_sig_gallery_version_prefix()}"
         for node in nodes["items"]:
             node_name = node["metadata"]["name"]
 
-            kubelet_ver = node["status"]["nodeInfo"]["kubeletVersion"]
-            if kubelet_ver != expected_ver:
+            kubelet_ver: str = node["status"]["nodeInfo"]["kubeletVersion"]
+            # relax the version match logic to within same minor version
+            if not kubelet_ver.startswith(expected_ver):
                 raise e2e_exceptions.VersionMismatch(
                     f"Wrong kubelet version on node {node_name}. "
                     f"Expected {expected_ver}, but found {kubelet_ver}")
 
-            kube_proxy_ver = node["status"]["nodeInfo"]["kubeProxyVersion"]
+            kube_proxy_ver: str = node["status"]["nodeInfo"]["kubeProxyVersion"]
             # Deprecated KubeProxy Version Reporting: https://github.com/kubernetes/kubernetes/commit/98c29f0312190904f55d62a4b4820fc17119ec10 
-            if kube_proxy_ver != "" and kube_proxy_ver != expected_ver:
+            if kube_proxy_ver != "" and not kube_proxy_ver.startswith(expected_ver):
                 raise e2e_exceptions.VersionMismatch(
                     f"Wrong kube-proxy version on node {node_name}. "
                     f"Expected {expected_ver}, but found {kube_proxy_ver}")

--- a/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
@@ -103,16 +103,26 @@ class CapzFlannelCI(e2e_base.CI):
         return "ubuntu-2204-gen1"
 
     @property
-    def capz_images_windows_sku(self):
+    def os_version(self):
         if self.opts.win_os == "ltsc2019":
             os_version = 2019
         elif self.opts.win_os == "ltsc2022":
             os_version = 2022
+        elif self.opts.win_os == "ltsc2025":
+            os_version = 2025
         else:
             raise e2e_exceptions.InvalidOperatingSystem(
                 f"Unknown win_os: {self.opts.win_os}"
             )
-        return f"windows-{os_version}-containerd-gen1"
+        return os_version
+
+    @property
+    def capz_images_windows_name(self):
+        return f"windows-{self.os_version}-containerd-gen1"
+
+    @property
+    def capz_sig_windows_image_name(self):
+        return f"capi-win-{self.os_version}-containerd"
 
     @property
     def k8s_path(self):
@@ -529,9 +539,6 @@ class CapzFlannelCI(e2e_base.CI):
         capz_image_ubuntu_version = self._capz_image_latest_version(
             self.capz_images_linux_offer, self.capz_images_ubuntu_sku
         )
-        capz_image_windows_version = self._capz_image_latest_version(
-            self.capz_images_windows_offer, self.capz_images_windows_sku
-        )
         context = {
             "cluster_name": self.opts.cluster_name,
             "resource_group_tags": self.resource_group_tags,
@@ -566,11 +573,10 @@ class CapzFlannelCI(e2e_base.CI):
 
             "capz_image_publisher": self.capz_images_publisher,
             "capz_image_ubuntu_offer": self.capz_images_linux_offer,
-            "capz_image_windows_offer": self.capz_images_windows_offer,
             "capz_image_ubuntu_sku": self.capz_images_ubuntu_sku,
-            "capz_image_windows_sku": self.capz_images_windows_sku,
             "capz_image_ubuntu_version": capz_image_ubuntu_version,
-            "capz_image_windows_version": capz_image_windows_version,
+            "capz_sig_windows_image_name": self.capz_sig_windows_image_name,
+            "capz_sig_windows_image_version": self.opts.kubernetes_version
         }
         return context
 

--- a/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
+++ b/e2e-runner/e2e_runner/ci/capz_flannel/capz_flannel.py
@@ -597,9 +597,9 @@ class CapzFlannelCI(e2e_base.CI):
         v = ver.strip("v").split(".")
         return f"{v[0]}{v[1]}.{v[2]}"
     
-    def _capz_sig_gallery_version_prefix(self):
+    def _capz_sig_gallery_version_prefix(self, is_node_setup = False):
         ver = self.kubernetes_version
-        if "k8sbins" in self.bins_built:
+        if "k8sbins" in self.bins_built and is_node_setup:
             ver = e2e_constants.DEFAULT_KUBERNETES_VERSION
         v = ver.strip("v").split(".")
         return f"{v[0]}.{v[1]}"
@@ -611,7 +611,7 @@ class CapzFlannelCI(e2e_base.CI):
                 public_gallery_name=gallery_name,
                 gallery_image_name=image_name
             )
-        prefix = self._capz_sig_gallery_version_prefix()
+        prefix = self._capz_sig_gallery_version_prefix(is_node_setup=True)
         vers = [i.name for i in img_vers if i.name.startswith(prefix)]
         vers.sort()
         return vers[-1]

--- a/e2e-runner/e2e_runner/cli/run_ci.py
+++ b/e2e-runner/e2e_runner/cli/run_ci.py
@@ -192,7 +192,7 @@ class RunCI(Command):
         p.add_argument(
             "--win-os",
             default="ltsc2022",
-            choices=["ltsc2019", "ltsc2022"],
+            choices=["ltsc2019", "ltsc2022", "ltsc2025"],
             help="The operating system of the K8s Windows agents.")
         p.add_argument(
             "--win-agent-size",

--- a/e2e-runner/e2e_runner/constants.py
+++ b/e2e-runner/e2e_runner/constants.py
@@ -1,14 +1,5 @@
 AZURE_LOCATIONS = [
-    "canadacentral",
-    "centralus",
-    "eastus",
-    "eastus2",
-    "northeurope",
-    "northcentralus",
-    "southcentralus",
-    "uksouth",
-    "westeurope",
-    "westus2",
+    "northcentralus"
 ]
 
 COMPUTE_QUOTAS = [

--- a/e2e-runner/e2e_runner/constants.py
+++ b/e2e-runner/e2e_runner/constants.py
@@ -4,6 +4,7 @@ AZURE_LOCATIONS = [
     "eastus",
     "eastus2",
     "northeurope",
+    "northcentralus",
     "southcentralus",
     "uksouth",
     "westeurope",
@@ -25,8 +26,8 @@ NETWORK_QUOTAS = [
     "RouteTables",
 ]
 
-DEFAULT_KUBERNETES_VERSION = "v1.28.10"
-DEFAULT_AKS_VERSION = "1.28"
+DEFAULT_KUBERNETES_VERSION = "v1.30.6"
+DEFAULT_AKS_VERSION = "1.30.6"
 
 FLANNEL_NAMESPACE = "kube-flannel"
 FLANNEL_HELM_REPO = "https://flannel-io.github.io/flannel"

--- a/e2e-runner/e2e_runner/templates/capz/control-plane.yaml.j2
+++ b/e2e-runner/e2e_runner/templates/capz/control-plane.yaml.j2
@@ -110,8 +110,7 @@ spec:
       enableIPForwarding: true
 {%- endif %}
       image:
-        marketplace:
-          publisher: {{ capz_image_publisher }}
-          offer: {{ capz_image_ubuntu_offer }}
-          sku: {{ capz_image_ubuntu_sku }}
-          version: {{ capz_image_ubuntu_version }}
+        computeGallery:
+          name: {{ capz_sig_ubuntu_image_name  }}
+          gallery: "ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019"
+          version: {{ capz_sig_ubuntu_image_version }}

--- a/e2e-runner/e2e_runner/templates/capz/windows-agents.yaml.j2
+++ b/e2e-runner/e2e_runner/templates/capz/windows-agents.yaml.j2
@@ -42,11 +42,10 @@ spec:
       enableIPForwarding: true
 {%- endif %}
       image:
-        marketplace:
-          publisher: {{ capz_image_publisher }}
-          offer: {{ capz_image_windows_offer }}
-          sku: {{ capz_image_windows_sku }}
-          version: {{ capz_image_windows_version }}
+        computeGallery:
+          name: {{ capz_sig_windows_image_name  }}
+          gallery: "ClusterAPI-f72ceb4f-5159-4c26-a0fe-2ea738f0d019"
+          version: {{ capz_sig_windows_image_version }}
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate

--- a/prow/jobs/sig-windows-networking.yaml
+++ b/prow/jobs/sig-windows-networking.yaml
@@ -1,6 +1,58 @@
 periodics:
-- name: k8s-e2e-ltsc2022-containerd-flannel-sdnbridge-master
+- name: k8s-e2e-ltsc2025-containerd-flannel-sdnbridge-master
   cron: "0 2 */2 * *"
+  always_run: true
+  labels:
+    preset-github-readonly-token: "true"
+    preset-ssh-key: "true"
+    preset-prod-azure-account: "true"
+    preset-windows-private-registry-cred: "true"
+  spec:
+    containers:
+    - image: ghcr.io/e2e-win/k8s-e2e-runner:main
+      imagePullPolicy: Always
+      command:
+        - /workspace/entrypoint.sh
+      args:
+        - --test-regex-file-url=https://raw.githubusercontent.com/e2e-win/k8s-e2e-runner/main/prow/test-regex/capz_flannel.yaml
+        - --build=k8sbins
+        - --build=containerdbins
+        - --build=sdncnibins
+        - capz_flannel
+        - --cni-version=1.0.0
+        - --bootstrap-vm-size=Standard_D8s_v3
+        - --flannel-mode=host-gw
+        - --win-os=ltsc2025
+        - --cluster-name=capzctrd
+
+- name: k8s-e2e-ltsc2025-containerd-flannel-sdnoverlay-master
+  cron: "0 4 */2 * *"
+  always_run: true
+  labels:
+    preset-github-readonly-token: "true"
+    preset-ssh-key: "true"
+    preset-prod-azure-account: "true"
+    preset-windows-private-registry-cred: "true"
+  spec:
+    containers:
+    - image: ghcr.io/e2e-win/k8s-e2e-runner:main
+      imagePullPolicy: Always
+      command:
+        - /workspace/entrypoint.sh
+      args:
+        - --test-regex-file-url=https://raw.githubusercontent.com/e2e-win/k8s-e2e-runner/main/prow/test-regex/capz_flannel.yaml
+        - --build=k8sbins
+        - --build=containerdbins
+        - --build=sdncnibins
+        - capz_flannel
+        - --cni-version=1.0.0
+        - --bootstrap-vm-size=Standard_D8s_v3
+        - --flannel-mode=vxlan
+        - --win-os=ltsc2025
+        - --cluster-name=capzctrd
+
+- name: k8s-e2e-ltsc2022-containerd-flannel-sdnbridge-master
+  cron: "0 6 */2 * *"
   always_run: true
   labels:
     preset-github-readonly-token: "true"
@@ -26,7 +78,7 @@ periodics:
         - --cluster-name=capzctrd
 
 - name: k8s-e2e-ltsc2022-containerd-flannel-sdnoverlay-master
-  cron: "0 6 */2 * *"
+  cron: "0 8 */2 * *"
   always_run: true
   labels:
     preset-github-readonly-token: "true"


### PR DESCRIPTION
- add Server 2025 tests
- use ubuntu 2404 from community gallery
- update versioning logic to match community gallery versions
- limit regions to north central us for availability of images