### PR TITLE
temp: revert ubuntu 24.04 upgrade to investigate pip install break

### DIFF
--- a/e2e-runner/Dockerfile
+++ b/e2e-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 
 ARG CAPI_VERSION=v1.8.4
 ARG KUBECTL_VERSION=v1.30.6
@@ -16,7 +16,7 @@ RUN apt-get autoclean && \
 
 # Install Python dependencies
 ADD requirements.txt /tmp
-RUN pip3 install -r /tmp/requirements.txt --break-system-packages && \
+RUN pip3 install -r /tmp/requirements.txt && \
     rm /tmp/requirements.txt
 
 # Install clusterctl


### PR DESCRIPTION
Hitting this error remotely that isn't occurring locally when I build the image

```
× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.
note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP [6](https://prow.k8s.io/view/gs/k8s-ovn/logs/aks-e2e-ltsc2022-azurecni-1.30/1868944408733290496#1:build-log.txt%3A6)68 for the detailed specification.
```