### PR TITLE
remove deprecated kube-apiserver cloud-provider arg

### DIFF
--- a/e2e-runner/e2e_runner/templates/capz/control-plane.yaml.j2
+++ b/e2e-runner/e2e_runner/templates/capz/control-plane.yaml.j2
@@ -8,8 +8,6 @@ spec:
   kubeadmConfigSpec:
     clusterConfiguration:
       apiServer:
-        extraArgs:
-          cloud-provider: external
         timeoutForControlPlane: 20m
       controllerManager:
         extraArgs:


### PR DESCRIPTION
This PR:

- removes the deprecated kube-apiserver cloud-provider arg which was deprecated in [release 1.29](https://github.com/kubernetes/kubernetes/blob/f0077a3689669018557de723a0416fda267d132f/CHANGELOG/CHANGELOG-1.29.md#:~:text=%40sttts\)-,Deprecated%20the%20%2D%2Dcloud%2Dprovider%20and%20%2D%2Dcloud%2Dconfig%20CLI%20parameters%20in%20kube%2Dapiserver.%20These%20parameters%20will%20be%20removed%20in%20a%20future%20release.%20\(%23120903%2C%20%40dims\)%20%5BSIG%20API%20Machinery%5D,-Dynamic%20resource%20allocation)
- it has been removed in release 1.33 through this [PR](https://github.com/kubernetes/kubernetes/pull/130162)